### PR TITLE
feature: Speed up deploy builds by using the github cache

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -55,13 +55,15 @@ jobs:
       - name: Validate Gradle wrapper
         uses: gradle/wrapper-validation-action@v1
       - name: Test project
+        # only run tests on dev
+        if: ${{ inputs.stage == 'dev'}}
         env:
           GHL_USERNAME: ${{ secrets.GHL_USERNAME }}
           GHL_PASSWORD: ${{ secrets.GHL_PASSWORD }}
         run: ./gradlew --no-daemon test
         shell: bash
       - name: Upload test results
-        if: ${{ always() }}
+        if: ${{ inputs.stage == 'dev' && always() }}
         uses: actions/upload-artifact@v3
         with:
           name: test-result
@@ -70,6 +72,7 @@ jobs:
             /home/runner/.gradle/daemon/**/daemon-*.out.log
           retention-days: 2
       - name: Clean up project
+        if: ${{ inputs.stage == 'dev'}}
         env:
           GHL_USERNAME: ${{ secrets.GHL_USERNAME }}
           GHL_PASSWORD: ${{ secrets.GHL_PASSWORD }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -55,15 +55,13 @@ jobs:
       - name: Validate Gradle wrapper
         uses: gradle/wrapper-validation-action@v1
       - name: Test project
-        # only do the full test build on production deploys - the code is also build in the docker file
-        if: ${{ inputs.stage == 'production'}}
         env:
           GHL_USERNAME: ${{ secrets.GHL_USERNAME }}
           GHL_PASSWORD: ${{ secrets.GHL_PASSWORD }}
         run: ./gradlew --no-daemon test
         shell: bash
       - name: Upload test results
-        if: ${{ inputs.stage == 'production' && always() }}
+        if: ${{ always() }}
         uses: actions/upload-artifact@v3
         with:
           name: test-result
@@ -72,7 +70,6 @@ jobs:
             /home/runner/.gradle/daemon/**/daemon-*.out.log
           retention-days: 2
       - name: Clean up project
-        if: ${{ inputs.stage == 'production'}}
         env:
           GHL_USERNAME: ${{ secrets.GHL_USERNAME }}
           GHL_PASSWORD: ${{ secrets.GHL_PASSWORD }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -10,7 +10,7 @@ on:
       stage:
         required: true
         type: string
-        description: 'stage being released (dev,staging,production'
+        description: 'stage being released (dev,staging,production)'
       service:
         required: true
         type: string
@@ -51,16 +51,19 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '17'
+          cache: 'gradle'
       - name: Validate Gradle wrapper
         uses: gradle/wrapper-validation-action@v1
       - name: Test project
+        # only do the full test build on production deploys - the code is also build in the docker file
+        if: ${{ inputs.stage == 'production'}}
         env:
           GHL_USERNAME: ${{ secrets.GHL_USERNAME }}
           GHL_PASSWORD: ${{ secrets.GHL_PASSWORD }}
         run: ./gradlew --no-daemon test
         shell: bash
       - name: Upload test results
-        if: ${{ always() }}
+        if: ${{ inputs.stage == 'production' && always() }}
         uses: actions/upload-artifact@v3
         with:
           name: test-result
@@ -69,6 +72,7 @@ jobs:
             /home/runner/.gradle/daemon/**/daemon-*.out.log
           retention-days: 2
       - name: Clean up project
+        if: ${{ inputs.stage == 'production'}}
         env:
           GHL_USERNAME: ${{ secrets.GHL_USERNAME }}
           GHL_PASSWORD: ${{ secrets.GHL_PASSWORD }}


### PR DESCRIPTION
@BrianEstrada I know we talked about using the cache might be problematic on deployements. But we are building again inside the docker files, so I would like to speed up our deployments a bit.

We might even consider removing the gradle test on these deploys - maybe keep them on the `development` branch because something might be committed directly into that. But for  `staging` and `production` it might not be needed to run the build and test on the runner?