### PR TITLE
chore: update description for "service-identifier" parameter

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -13,7 +13,7 @@ on:
       service-identifier:
         required: true
         type: string
-        description: 'Identifier of the service being released i.e service-ocpp, service-vehicle'
+        description: 'Identifier of the service being released i.e ocpp, vehicle, server, wallet.'
       gradle-module:
         required: false
         type: string


### PR DESCRIPTION
Examples should not include the `service-` prefix, as that would deploy to wrong path in kube-manifests.