### PR TITLE
feat(v2): Allow use static keys or assumed role

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -148,20 +148,25 @@ jobs:
           java-version: '17'
       - name: Validate Gradle wrapper
         uses: gradle/wrapper-validation-action@v1
+      - name: Check for secret.AWS_ACCOUNT_ID availability
+        id: secret-check
+        shell: bash
+        run: |
+          if [ "${{ secrets.AWS_ACCOUNT_ID }}" != '' ]; then
+            echo "available=true" >> $GITHUB_OUTPUT;
+          else
+            echo "available=false" >> $GITHUB_OUTPUT;
+          fi
       - name: Configure AWS credentials via assumed role
         uses: aws-actions/configure-aws-credentials@v1
-        if: ${{ env.AWS_ACCOUNT_ID }} != ""
-        env:
-          AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCESS_ID }}
+        if: steps.secret-check.outputs.available == 'true'
         with:
-          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/ecr-put-image
+          role-to-a ssume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/ecr-put-image
           role-session-name: push-new-image-to-${{ inputs.service-identifier }}-${{ inputs.stage }}
           aws-region: ${{ inputs.region }}
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1
-        if: ${{ env.AWS_ACCOUNT_ID }} == ""
-        env:
-          AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCESS_ID }}
+        if: steps.secret-check.outputs.available == 'false'
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -161,7 +161,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@v1
         if: steps.secret-check.outputs.available == 'true'
         with:
-          role-to-a ssume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/ecr-put-image
+          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/ecr-put-image
           role-session-name: push-new-image-to-${{ inputs.service-identifier }}-${{ inputs.stage }}
           aws-region: ${{ inputs.region }}
       - name: Configure AWS credentials

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -40,8 +40,14 @@ on:
         required: true
         description: 'Github Password (Gradle plugin)'
       AWS_ACCOUNT_ID:
-        required: true
+        required: false
         description: 'AWS account id'
+      AWS_ACCESS_KEY_ID:
+        required: false
+        description: 'AWS access key id'
+      AWS_SECRET_ACCESS_KEY:
+        required: false
+        description: 'AWS secret access key'
       MANIFEST_REPO_PAT:
         required: true
         description: 'GitHub personal access token'
@@ -142,11 +148,19 @@ jobs:
           java-version: '17'
       - name: Validate Gradle wrapper
         uses: gradle/wrapper-validation-action@v1
-      - name: Configure AWS credentials
+      - name: Configure AWS credentials via assumed role
         uses: aws-actions/configure-aws-credentials@v1
+        if: ${{ secrets.AWS_ACCOUNT_ID }} != "" && ${{ secrets.AWS_ACCESS_KEY_ID }} == "" && ${{ secrets.AWS_SECRET_ACCESS_KEY }} == ""
         with:
           role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/ecr-put-image
           role-session-name: push-new-image-to-${{ inputs.service-identifier }}-${{ inputs.stage }}
+          aws-region: ${{ inputs.region }}
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        if: ${{ secrets.AWS_ACCOUNT_ID }} == "" && ${{ secrets.AWS_ACCESS_KEY_ID }} != "" && ${{ secrets.AWS_SECRET_ACCESS_KEY }} != ""
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ inputs.region }}
       - name: Login to Amazon ECR
         id: login-ecr

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -150,14 +150,18 @@ jobs:
         uses: gradle/wrapper-validation-action@v1
       - name: Configure AWS credentials via assumed role
         uses: aws-actions/configure-aws-credentials@v1
-        if: ${{ secrets.AWS_ACCOUNT_ID }} != "" && ${{ secrets.AWS_ACCESS_KEY_ID }} == "" && ${{ secrets.AWS_SECRET_ACCESS_KEY }} == ""
+        if: ${{ env.AWS_ACCOUNT_ID }} != ""
+        env:
+          AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCESS_ID }}
         with:
           role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/ecr-put-image
           role-session-name: push-new-image-to-${{ inputs.service-identifier }}-${{ inputs.stage }}
           aws-region: ${{ inputs.region }}
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1
-        if: ${{ secrets.AWS_ACCOUNT_ID }} == "" && ${{ secrets.AWS_ACCESS_KEY_ID }} != "" && ${{ secrets.AWS_SECRET_ACCESS_KEY }} != ""
+        if: ${{ env.AWS_ACCOUNT_ID }} == ""
+        env:
+          AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCESS_ID }}
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
Support easy switch between static keys and assumed role.
This way, we won't broke any existing workflows and it is easier for us to switch back to static keys if needed.

- When `secrets.AWS_ACCOUNT_ID` is given, use the step `Configure AWS credentials via assumed role` and skip step `Configure AWS credentials`. [Example workflow run](https://github.com/monta-app/service-cpi-api/actions/runs/4566085533/jobs/8059204702).
  
  <img width="395" alt="image" src="https://user-images.githubusercontent.com/26658608/228905924-ee48c4ba-b5eb-4422-b908-ad81935c3ad4.png">

- If `secrets.AWS_ACCOUNT_ID` is not given, the other way around. [Example workflow run](https://github.com/monta-app/service-cpi-api/actions/runs/4566169018/jobs/8058970505).
  
  <img width="451" alt="image" src="https://user-images.githubusercontent.com/26658608/228896009-3ce34fc5-bd49-4fd8-9143-801a275e1fce.png">
