### PR TITLE
fix: argument list too long

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -80,8 +80,7 @@ jobs:
       slack-message-id: ${{ steps.publish-slack.outputs.slack-message-id }}
     steps:
       - name: Publish progress message to slack
-        uses: monta-app/slack-notifier-cli-action@fix-arg-list-too-long
-#        uses: monta-app/slack-notifier-cli-action@main
+        uses: monta-app/slack-notifier-cli-action@main
         id: publish-slack
         with:
           job-type: "test"
@@ -130,8 +129,7 @@ jobs:
             /home/runner/.gradle/daemon/**/daemon-*.out.log
           retention-days: 2
       - name: Publish result message to slack
-        uses: monta-app/slack-notifier-cli-action@fix-arg-list-too-long
-#        uses: monta-app/slack-notifier-cli-action@main
+        uses: monta-app/slack-notifier-cli-action@main
         if: always()
         with:
           job-type: "test"
@@ -157,8 +155,7 @@ jobs:
     steps:
       - name: Publish progress message to slack
         if: runner.arch == 'X64'
-        uses: monta-app/slack-notifier-cli-action@fix-arg-list-too-long
-#        uses: monta-app/slack-notifier-cli-action@main
+        uses: monta-app/slack-notifier-cli-action@main
         id: publish-slack
         with:
           job-type: "build"
@@ -287,8 +284,7 @@ jobs:
           docker manifest inspect $ECR_IMAGE_URL:latest
           docker manifest push $ECR_IMAGE_URL:latest
       - name: Publish result message to slack
-        uses: monta-app/slack-notifier-cli-action@fix-arg-list-too-long
-#        uses: monta-app/slack-notifier-cli-action@main
+        uses: monta-app/slack-notifier-cli-action@main
         if: ${{ always() }}
         id: publish-slack
         with:
@@ -307,8 +303,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Publish progress message to slack
-        uses: monta-app/slack-notifier-cli-action@fix-arg-list-too-long
-#        uses: monta-app/slack-notifier-cli-action@main
+        uses: monta-app/slack-notifier-cli-action@main
         id: publish-slack
         with:
           job-type: "deploy"
@@ -345,8 +340,7 @@ jobs:
           directory: './manifests'
           repository: monta-app/kube-manifests
       - name: Publish result message to slack
-        uses: monta-app/slack-notifier-cli-action@fix-arg-list-too-long
-#        uses: monta-app/slack-notifier-cli-action@main
+        uses: monta-app/slack-notifier-cli-action@main
         if: always()
         with:
           job-type: "deploy"
@@ -367,8 +361,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Publish result message to slack
-        uses: monta-app/slack-notifier-cli-action@fix-arg-list-too-long
-#        uses: monta-app/slack-notifier-cli-action@main
+        uses: monta-app/slack-notifier-cli-action@main
         if: ${{ always() }}
         with:
           job-type: "build"

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -37,6 +37,11 @@ on:
         type: string
         description: the version of the java docker image to build
         default: "17.0.7"
+      slack-channel-id:
+        required: false
+        type: string
+        description: 'ID of slack channel to notify with build status. Default value is the "deployment" channel, only override in special cases.'
+        default: "C01KL9FUPNK"
     secrets:
       GHL_USERNAME:
         required: true
@@ -83,7 +88,7 @@ jobs:
           service-name: ${{ inputs.service-name }}
           service-emoji: ${{ inputs.service-emoji }}
           slack-app-token: ${{ secrets.SLACK_APP_TOKEN }}
-          slack-channel-id: "C01KL9FUPNK"
+          slack-channel-id: ${{ inputs.slack-channel-id }}
 
   test:
     name: Test
@@ -132,7 +137,7 @@ jobs:
           service-name: ${{ inputs.service-name }}
           service-emoji: ${{ inputs.service-emoji }}
           slack-app-token: ${{ secrets.SLACK_APP_TOKEN }}
-          slack-channel-id: "C01KL9FUPNK"
+          slack-channel-id: ${{ inputs.slack-channel-id }}
           slack-message-id: ${{ needs.init_message.outputs.slack-message-id }}
 
   build:
@@ -158,7 +163,7 @@ jobs:
           service-name: ${{ inputs.service-name }}
           service-emoji: ${{ inputs.service-emoji }}
           slack-app-token: ${{ secrets.SLACK_APP_TOKEN }}
-          slack-channel-id: "C01KL9FUPNK"
+          slack-channel-id: ${{ inputs.slack-channel-id }}
           slack-message-id: ${{ needs.init_message.outputs.slack-message-id }}
       - name: Checkout
         uses: actions/checkout@v3
@@ -288,7 +293,7 @@ jobs:
           service-name: ${{ inputs.service-name }}
           service-emoji: ${{ inputs.service-emoji }}
           slack-app-token: ${{ secrets.SLACK_APP_TOKEN }}
-          slack-channel-id: "C01KL9FUPNK"
+          slack-channel-id: ${{ inputs.slack-channel-id }}
           slack-message-id: ${{ needs.test.outputs.slack-message-id }}
 
   deploy:
@@ -306,7 +311,7 @@ jobs:
           service-name: ${{ inputs.service-name }}
           service-emoji: ${{ inputs.service-emoji }}
           slack-app-token: ${{ secrets.SLACK_APP_TOKEN }}
-          slack-channel-id: "C01KL9FUPNK"
+          slack-channel-id: ${{ inputs.slack-channel-id }}
           slack-message-id: ${{ needs.push-manifest-list.outputs.slack-message-id }}
       - name: Check out manifest repository
         uses: actions/checkout@master
@@ -343,7 +348,7 @@ jobs:
           service-name: ${{ inputs.service-name }}
           service-emoji: ${{ inputs.service-emoji }}
           slack-app-token: ${{ secrets.SLACK_APP_TOKEN }}
-          slack-channel-id: "C01KL9FUPNK"
+          slack-channel-id: ${{ inputs.slack-channel-id }}
           slack-message-id: ${{ steps.publish-slack.outputs.slack-message-id }}
 
   # needed because can't run slack notifier cli on arm64, so can't update with always() in the same build job
@@ -364,5 +369,5 @@ jobs:
           service-name: ${{ inputs.service-name }}
           service-emoji: ${{ inputs.service-emoji }}
           slack-app-token: ${{ secrets.SLACK_APP_TOKEN }}
-          slack-channel-id: "C01KL9FUPNK"
+          slack-channel-id: ${{ inputs.slack-channel-id }}
           slack-message-id: ${{ needs.init_message.outputs.slack-message-id }}

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -80,7 +80,7 @@ jobs:
       slack-message-id: ${{ steps.publish-slack.outputs.slack-message-id }}
     steps:
       - name: Publish progress message to slack
-        uses: monta-app/slack-notifier-cli-action@feat/fix-arg-list-too-long
+        uses: monta-app/slack-notifier-cli-action@fix-arg-list-too-long
 #        uses: monta-app/slack-notifier-cli-action@main
         id: publish-slack
         with:
@@ -130,7 +130,7 @@ jobs:
             /home/runner/.gradle/daemon/**/daemon-*.out.log
           retention-days: 2
       - name: Publish result message to slack
-        uses: monta-app/slack-notifier-cli-action@feat/fix-arg-list-too-long
+        uses: monta-app/slack-notifier-cli-action@fix-arg-list-too-long
 #        uses: monta-app/slack-notifier-cli-action@main
         if: always()
         with:
@@ -157,7 +157,7 @@ jobs:
     steps:
       - name: Publish progress message to slack
         if: runner.arch == 'X64'
-        uses: monta-app/slack-notifier-cli-action@feat/fix-arg-list-too-long
+        uses: monta-app/slack-notifier-cli-action@fix-arg-list-too-long
 #        uses: monta-app/slack-notifier-cli-action@main
         id: publish-slack
         with:
@@ -287,7 +287,7 @@ jobs:
           docker manifest inspect $ECR_IMAGE_URL:latest
           docker manifest push $ECR_IMAGE_URL:latest
       - name: Publish result message to slack
-        uses: monta-app/slack-notifier-cli-action@feat/fix-arg-list-too-long
+        uses: monta-app/slack-notifier-cli-action@fix-arg-list-too-long
 #        uses: monta-app/slack-notifier-cli-action@main
         if: ${{ always() }}
         id: publish-slack
@@ -307,7 +307,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Publish progress message to slack
-        uses: monta-app/slack-notifier-cli-action@feat/fix-arg-list-too-long
+        uses: monta-app/slack-notifier-cli-action@fix-arg-list-too-long
 #        uses: monta-app/slack-notifier-cli-action@main
         id: publish-slack
         with:
@@ -345,7 +345,7 @@ jobs:
           directory: './manifests'
           repository: monta-app/kube-manifests
       - name: Publish result message to slack
-        uses: monta-app/slack-notifier-cli-action@feat/fix-arg-list-too-long
+        uses: monta-app/slack-notifier-cli-action@fix-arg-list-too-long
 #        uses: monta-app/slack-notifier-cli-action@main
         if: always()
         with:
@@ -367,7 +367,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Publish result message to slack
-        uses: monta-app/slack-notifier-cli-action@feat/fix-arg-list-too-long
+        uses: monta-app/slack-notifier-cli-action@fix-arg-list-too-long
 #        uses: monta-app/slack-notifier-cli-action@main
         if: ${{ always() }}
         with:

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -80,7 +80,8 @@ jobs:
       slack-message-id: ${{ steps.publish-slack.outputs.slack-message-id }}
     steps:
       - name: Publish progress message to slack
-        uses: monta-app/slack-notifier-cli-action@main
+        uses: monta-app/slack-notifier-cli-action@feat/fix-arg-list-too-long
+#        uses: monta-app/slack-notifier-cli-action@main
         id: publish-slack
         with:
           job-type: "test"
@@ -129,7 +130,8 @@ jobs:
             /home/runner/.gradle/daemon/**/daemon-*.out.log
           retention-days: 2
       - name: Publish result message to slack
-        uses: monta-app/slack-notifier-cli-action@main
+        uses: monta-app/slack-notifier-cli-action@feat/fix-arg-list-too-long
+#        uses: monta-app/slack-notifier-cli-action@main
         if: always()
         with:
           job-type: "test"
@@ -155,7 +157,8 @@ jobs:
     steps:
       - name: Publish progress message to slack
         if: runner.arch == 'X64'
-        uses: monta-app/slack-notifier-cli-action@main
+        uses: monta-app/slack-notifier-cli-action@feat/fix-arg-list-too-long
+#        uses: monta-app/slack-notifier-cli-action@main
         id: publish-slack
         with:
           job-type: "build"
@@ -284,7 +287,8 @@ jobs:
           docker manifest inspect $ECR_IMAGE_URL:latest
           docker manifest push $ECR_IMAGE_URL:latest
       - name: Publish result message to slack
-        uses: monta-app/slack-notifier-cli-action@main
+        uses: monta-app/slack-notifier-cli-action@feat/fix-arg-list-too-long
+#        uses: monta-app/slack-notifier-cli-action@main
         if: ${{ always() }}
         id: publish-slack
         with:
@@ -303,7 +307,8 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Publish progress message to slack
-        uses: monta-app/slack-notifier-cli-action@main
+        uses: monta-app/slack-notifier-cli-action@feat/fix-arg-list-too-long
+#        uses: monta-app/slack-notifier-cli-action@main
         id: publish-slack
         with:
           job-type: "deploy"
@@ -340,7 +345,8 @@ jobs:
           directory: './manifests'
           repository: monta-app/kube-manifests
       - name: Publish result message to slack
-        uses: monta-app/slack-notifier-cli-action@main
+        uses: monta-app/slack-notifier-cli-action@feat/fix-arg-list-too-long
+#        uses: monta-app/slack-notifier-cli-action@main
         if: always()
         with:
           job-type: "deploy"
@@ -361,7 +367,8 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Publish result message to slack
-        uses: monta-app/slack-notifier-cli-action@main
+        uses: monta-app/slack-notifier-cli-action@feat/fix-arg-list-too-long
+#        uses: monta-app/slack-notifier-cli-action@main
         if: ${{ always() }}
         with:
           job-type: "build"

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -78,7 +78,6 @@ jobs:
         uses: monta-app/slack-notifier-cli-action@main
         id: publish-slack
         with:
-          github-context: ${{ toJson(github) }}
           job-type: "test"
           job-status: "progress"
           service-name: ${{ inputs.service-name }}
@@ -128,7 +127,6 @@ jobs:
         uses: monta-app/slack-notifier-cli-action@main
         if: always()
         with:
-          github-context: ${{ toJson(github) }}
           job-type: "test"
           job-status: ${{ job.status }}
           service-name: ${{ inputs.service-name }}
@@ -155,7 +153,6 @@ jobs:
         uses: monta-app/slack-notifier-cli-action@main
         id: publish-slack
         with:
-          github-context: ${{ toJson(github) }}
           job-type: "build"
           job-status: "progress"
           service-name: ${{ inputs.service-name }}
@@ -286,7 +283,6 @@ jobs:
         if: ${{ always() }}
         id: publish-slack
         with:
-          github-context: ${{ toJson(github) }}
           job-type: "build"
           job-status: ${{ needs.build.result }}
           service-name: ${{ inputs.service-name }}
@@ -305,7 +301,6 @@ jobs:
         uses: monta-app/slack-notifier-cli-action@main
         id: publish-slack
         with:
-          github-context: ${{ toJson(github) }}
           job-type: "deploy"
           job-status: "progress"
           service-name: ${{ inputs.service-name }}
@@ -343,7 +338,6 @@ jobs:
         uses: monta-app/slack-notifier-cli-action@main
         if: always()
         with:
-          github-context: ${{ toJson(github) }}
           job-type: "deploy"
           job-status: ${{ job.status }}
           service-name: ${{ inputs.service-name }}
@@ -365,7 +359,6 @@ jobs:
         uses: monta-app/slack-notifier-cli-action@main
         if: ${{ always() }}
         with:
-          github-context: ${{ toJson(github) }}
           job-type: "build"
           job-status: ${{ needs.build.result }}
           service-name: ${{ inputs.service-name }}


### PR DESCRIPTION
Remove github context pass-on to eliminate "argument list too long" shell error in slack-notificer-cli-action due to huge environment data passed. Relates to https://github.com/monta-app/slack-notifier-cli-action/pull/4 and https://github.com/monta-app/slack-notifier-cli/pull/43.

Also add configurable slack channel with default to previous hardcoded value (the "deployment" channel)