### PR TITLE
fix: cast commit hashes to strings

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -501,9 +501,9 @@ jobs:
         working-directory: ./manifests/apps/${{ inputs.service-identifier }}/${{ inputs.stage }}/cluster
         run: |
           # Update previousHash
-          previousHash=$(yq e .currentHash config.yaml) yq e '.previousHash = env(previousHash)' -i config.yaml
+          previousHash=$(yq e .currentHash config.yaml) yq e '.previousHash = strenv(previousHash)' -i config.yaml
           # Update currentHash
-          currentHash=${GITHUB_SHA::8} yq e '.currentHash = env(currentHash)' -i config.yaml
+          currentHash=${GITHUB_SHA::8} yq e '.currentHash = strenv(currentHash)' -i config.yaml
       - name: Commit to manifest repository
         working-directory: './manifests'
         run: |


### PR DESCRIPTION
To ensure that hashes aren't going to be interpreted as numbers during diff-link generation, we cast the hashes to strings.

Based on the work done by @HotThoughts in https://github.com/monta-app/server/pull/9926