### PR TITLE
restructure

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -100,23 +100,14 @@ permissions:
   actions: read # This is required for 8398a7/action-slack
 
 jobs:
-  matrix-prep-config:
-    runs-on: ubuntu-latest
-    steps:
-    - id: x64
-      run: echo "runner=self-hosted-x64" >> $GITHUB_OUTPUT
-    - id: arm64
-      if: ${{ inputs.arm-build }}
-      run: echo "runner=self-hosted-arm64" >> $GITHUB_OUTPUT
-    outputs:
-      runners: ${{ toJSON(steps.*.outputs.runner) }}
-
-  init_message:
+  # needed in order for test and build to start independently while updating the same slack message
+  init:
     name: Sending first Slack message
     runs-on: ubuntu-latest
     timeout-minutes: 5
     outputs:
       slack-message-id: ${{ steps.publish-slack.outputs.slack-message-id }}
+      runners: ${{ toJSON(steps.*.outputs.runner) }}
     steps:
       - name: Publish progress message to slack
         uses: monta-app/slack-notifier-cli-action@main
@@ -128,14 +119,18 @@ jobs:
           service-emoji: ${{ inputs.service-emoji }}
           slack-app-token: ${{ secrets.SLACK_APP_TOKEN }}
           slack-channel-id: ${{ inputs.slack-channel-id }}
+      # calculates whether should run also on arm
+      - id: x64
+        run: echo "runner=self-hosted-x64" >> $GITHUB_OUTPUT
+      - id: arm64
+        if: ${{ inputs.arm-build }}
+        run: echo "runner=self-hosted-arm64" >> $GITHUB_OUTPUT
 
   test:
     name: Test
-    needs: init_message
+    needs: init
     runs-on: self-hosted-x64
     timeout-minutes: 30
-    outputs:
-      slack-message-id: ${{ needs.init_message.outputs.slack-message-id }}
     steps:
       - name: Download curl
         id: download-curl
@@ -183,7 +178,8 @@ jobs:
           service-emoji: ${{ inputs.service-emoji }}
           slack-app-token: ${{ secrets.SLACK_APP_TOKEN }}
           slack-channel-id: ${{ inputs.slack-channel-id }}
-          slack-message-id: ${{ needs.init_message.outputs.slack-message-id }}
+          slack-message-id: ${{ needs.init.outputs.slack-message-id }}
+
   get-manifest-info:
     if: ${{ inputs.upload-open-api }}
     name: Get manifest information
@@ -313,16 +309,12 @@ jobs:
 
   build:
     name: Build
-    needs:
-    - init_message
-    - matrix-prep-config
+    needs: init
     runs-on: ${{ matrix.runner-type }}
     timeout-minutes: 30
     strategy:
       matrix:
-        runner-type: ${{ fromJSON(needs.matrix-prep-config.outputs.runners) }}
-    outputs:
-      slack-message-id: ${{ needs.init_message.outputs.slack-message-id }}
+        runner-type: ${{ fromJSON(needs.init.outputs.runners) }}
     steps:
       - name: Download curl
         if: runner.arch == 'X64'
@@ -342,7 +334,7 @@ jobs:
           service-emoji: ${{ inputs.service-emoji }}
           slack-app-token: ${{ secrets.SLACK_APP_TOKEN }}
           slack-channel-id: ${{ inputs.slack-channel-id }}
-          slack-message-id: ${{ needs.init_message.outputs.slack-message-id }}
+          slack-message-id: ${{ needs.init.outputs.slack-message-id }}
       - name: Checkout
         uses: actions/checkout@v3
       - name: Set up JDK
@@ -407,15 +399,63 @@ jobs:
             ${{ steps.meta.outputs.labels }}
           tags: ${{ steps.meta.outputs.tags }}
 
+  # needed because can't run slack notifier cli on arm64, so can't update with always() in the same build job
+  update_build_fail:
+    name: Update Slack message for build fail
+    needs: [ init, build ]
+    if: failure()
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Publish result message to slack
+        uses: monta-app/slack-notifier-cli-action@main
+        if: ${{ always() }}
+        with:
+          job-type: "build"
+          job-status: ${{ needs.build.result }}
+          service-name: ${{ inputs.service-name }}
+          service-emoji: ${{ inputs.service-emoji }}
+          slack-app-token: ${{ secrets.SLACK_APP_TOKEN }}
+          slack-channel-id: ${{ inputs.slack-channel-id }}
+          slack-message-id: ${{ needs.init.outputs.slack-message-id }}
+
+  update_build_success:
+    name: Update Slack message for build success
+    needs: [ init, build ]
+    if: success()
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Publish result message to slack
+        uses: monta-app/slack-notifier-cli-action@main
+        if: ${{ always() }}
+        with:
+          job-type: "build"
+          job-status: ${{ needs.build.result }}
+          service-name: ${{ inputs.service-name }}
+          service-emoji: ${{ inputs.service-emoji }}
+          slack-app-token: ${{ secrets.SLACK_APP_TOKEN }}
+          slack-channel-id: ${{ inputs.slack-channel-id }}
+          slack-message-id: ${{ needs.init.outputs.slack-message-id }}
+
   push-manifest-list:
     name: Push Manifest
-    needs: [ build, test ]
+    needs: [ init, build, test ]
     if: success()
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    outputs:
-      slack-message-id: ${{ steps.publish-slack.outputs.slack-message-id }}
     steps:
+      - name: Publish progress message to slack
+        uses: monta-app/slack-notifier-cli-action@main
+        id: publish-slack
+        with:
+          job-type: "deploy"
+          job-status: "progress"
+          service-name: ${{ inputs.service-name }}
+          service-emoji: ${{ inputs.service-emoji }}
+          slack-app-token: ${{ secrets.SLACK_APP_TOKEN }}
+          slack-channel-id: ${{ inputs.slack-channel-id }}
+          slack-message-id: ${{ needs.init.outputs.slack-message-id }}
       - name: Check for secret.AWS_ACCOUNT_ID availability
         id: secret-check
         shell: bash
@@ -474,35 +514,25 @@ jobs:
           docker manifest push $ECR_IMAGE_URL:latest
       - name: Publish result message to slack
         uses: monta-app/slack-notifier-cli-action@main
-        if: ${{ always() }}
-        id: publish-slack
+        if: failure()
         with:
-          job-type: "build"
-          job-status: ${{ needs.build.result }}
+          job-type: "deploy"
+          job-status: ${{ job.status }}
           service-name: ${{ inputs.service-name }}
           service-emoji: ${{ inputs.service-emoji }}
           slack-app-token: ${{ secrets.SLACK_APP_TOKEN }}
           slack-channel-id: ${{ inputs.slack-channel-id }}
-          slack-message-id: ${{ needs.test.outputs.slack-message-id }}
+          slack-message-id: ${{ needs.init.outputs.slack-message-id }}
 
   deploy_by_push:
     if: ${{ inputs.push-to-manifests }}
     name: Deploy (push)
-    needs: push-manifest-list
+    needs:
+    - push-manifest-list
+    - init
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - name: Publish progress message to slack
-        uses: monta-app/slack-notifier-cli-action@main
-        id: publish-slack
-        with:
-          job-type: "deploy"
-          job-status: "progress"
-          service-name: ${{ inputs.service-name }}
-          service-emoji: ${{ inputs.service-emoji }}
-          slack-app-token: ${{ secrets.SLACK_APP_TOKEN }}
-          slack-channel-id: ${{ inputs.slack-channel-id }}
-          slack-message-id: ${{ needs.push-manifest-list.outputs.slack-message-id }}
       - name: Check out manifest repository
         uses: actions/checkout@master
         with:
@@ -547,26 +577,17 @@ jobs:
           service-emoji: ${{ inputs.service-emoji }}
           slack-app-token: ${{ secrets.SLACK_APP_TOKEN }}
           slack-channel-id: ${{ inputs.slack-channel-id }}
-          slack-message-id: ${{ steps.publish-slack.outputs.slack-message-id }}
+          slack-message-id: ${{ needs.init.outputs.slack-message-id }}
 
   deploy_by_argocd:
     if: ${{ ! inputs.push-to-manifests }}
     name: Deploy (ArgoCD)
-    needs: push-manifest-list
+    needs:
+    - push-manifest-list
+    - init
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - name: Publish progress message to slack
-        uses: monta-app/slack-notifier-cli-action@main
-        id: publish-slack
-        with:
-          job-type: "deploy"
-          job-status: "progress"
-          service-name: ${{ inputs.service-name }}
-          service-emoji: ${{ inputs.service-emoji }}
-          slack-app-token: ${{ secrets.SLACK_APP_TOKEN }}
-          slack-channel-id: ${{ inputs.slack-channel-id }}
-          slack-message-id: ${{ needs.push-manifest-list.outputs.slack-message-id }}
       - name: Download ArgoCD CLI
         shell: bash
         run: |
@@ -590,24 +611,4 @@ jobs:
           service-emoji: ${{ inputs.service-emoji }}
           slack-app-token: ${{ secrets.SLACK_APP_TOKEN }}
           slack-channel-id: ${{ inputs.slack-channel-id }}
-          slack-message-id: ${{ steps.publish-slack.outputs.slack-message-id }}
-  # needed because can't run slack notifier cli on arm64, so can't update with always() in the same build job
-  update_build_fail:
-    name: Update Slack message for build fail
-    # needs init_message in order to get the message id, because build might not output one if fails
-    needs: [ init_message, build ]
-    if: failure()
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    steps:
-      - name: Publish result message to slack
-        uses: monta-app/slack-notifier-cli-action@main
-        if: ${{ always() }}
-        with:
-          job-type: "build"
-          job-status: ${{ needs.build.result }}
-          service-name: ${{ inputs.service-name }}
-          service-emoji: ${{ inputs.service-emoji }}
-          slack-app-token: ${{ secrets.SLACK_APP_TOKEN }}
-          slack-channel-id: ${{ inputs.slack-channel-id }}
-          slack-message-id: ${{ needs.init_message.outputs.slack-message-id }}
+          slack-message-id: ${{ needs.init.outputs.slack-message-id }}


### PR DESCRIPTION
### Merged `matrix-prep-config` and `init_message`
- Mostly in order to save money instead of having multiple short running jobs that cost a lot of money
- Renamed `init_message` to `init`
- Same job produces both outputs

### Renamed all needs to `init`
- Every job that needs to send a slack message needs `init` in order to get the message ID. Easier to have one line with the same value, instead of having different dependent needs with the same value
- In addition, every job doesn't need to `output` the slack message ID anymore

### Jobs for update build status
- The `update_build_fail` didn't run in some cases, depends on the specific workflow
- Created two explicit success and fail jobs to update the build status, making sure it always runs

### The `deploy` message starts at `push-manifest-list`
- Will update fail status if couldn't push manifest to ECR as a conditional step
- The `deploy` message **ends** at `deploy_by_*`
