### PR TITLE
Update openapispec job to apply directly to the cluster

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -163,14 +163,14 @@ jobs:
           fi
           curl -sSL -o argocd https://github.com/argoproj/argo-cd/releases/latest/download/argocd-linux-amd64
           sudo chmod +x argocd
-          K8S_CLUSTER=$(./argocd --auth-token $ARGOCD_TOKEN --server $ARGOCD_SERVER app get argocd/${{ inputs.service-identifier }}-${{ inputs.stage }} -o yaml | yq '.spec.destination.cluster')
+          K8S_CLUSTER=$(./argocd --grpc-web --auth-token $ARGOCD_TOKEN --server $ARGOCD_SERVER app get argocd/${{ inputs.service-identifier }}-${{ inputs.stage }} -o yaml | yq '.spec.destination.cluster')
           if [ $K8S_CLUSTER == "main-prod" ]; then
             export K8S_CLUSTER="main-production"
           fi
           echo "cluster=$K8S_CLUSTER" >> "$GITHUB_OUTPUT"
-          K8S_NAMESPACE=$(./argocd --auth-token $ARGOCD_TOKEN --server $ARGOCD_SERVER app get argocd/${{ inputs.service-identifier }}-${{ inputs.stage }} -o yaml | yq '.spec.destination.namespace')
+          K8S_NAMESPACE=$(./argocd --grpc-web --auth-token $ARGOCD_TOKEN --server $ARGOCD_SERVER app get argocd/${{ inputs.service-identifier }}-${{ inputs.stage }} -o yaml | yq '.spec.destination.namespace')
           echo "namespace=$K8S_NAMESPACE" >> "$GITHUB_OUTPUT"
-          SERVICE_NAME=$(./argocd --auth-token $ARGOCD_TOKEN --server $ARGOCD_SERVER app manifests argocd/${{ inputs.service-identifier }}-${{ inputs.stage }} | yq 'select(di == 1) | .metadata.labels."app.kubernetes.io/name"')
+          SERVICE_NAME=$(./argocd --grpc-web --auth-token $ARGOCD_TOKEN --server $ARGOCD_SERVER app manifests argocd/${{ inputs.service-identifier }}-${{ inputs.stage }} | yq 'select(di == 1) | .metadata.labels."app.kubernetes.io/name"')
           echo "service-name=$SERVICE_NAME" >> "$GITHUB_OUTPUT"
       - name: Publish result message to slack
         uses: monta-app/slack-notifier-cli-action@main
@@ -617,9 +617,9 @@ jobs:
           ARGOCD_TOKEN: ${{ secrets.ARGOCD_TOKEN }}
           ARGOCD_SERVER: ${{ needs.init.outputs.argocd-server }}
         run: |
-          OLD_TAG=$(./argocd --auth-token $ARGOCD_TOKEN --server $ARGOCD_SERVER app get argocd/${{ inputs.service-identifier }}-${{ inputs.stage }} --show-params -o yaml | yq -e=0 '.spec.source.helm.parameters[] | select(.name == "image.tag").value')
-          ./argocd --auth-token $ARGOCD_TOKEN --server $ARGOCD_SERVER app patch ${{ inputs.service-identifier }}-${{ inputs.stage }} --patch='[{"op": "replace", "path": "/spec/info/0", "value": {"name": "Source Code Diff", "value": "'"https://github.com/${{ github.repository }}/compare/${OLD_TAG::8}...${GITHUB_SHA::8}"'"}}]'
-          ./argocd --auth-token $ARGOCD_TOKEN --server $ARGOCD_SERVER app set argocd/${{ inputs.service-identifier }}-${{ inputs.stage }} -p kotlin.revision=${GITHUB_SHA::8} -p kotlin.build=${{ github.run_number }} -p kotlin.image.tag=${GITHUB_SHA}
+          OLD_TAG=$(./argocd --grpc-web --auth-token $ARGOCD_TOKEN --server $ARGOCD_SERVER app get argocd/${{ inputs.service-identifier }}-${{ inputs.stage }} --show-params -o yaml | yq -e=0 '.spec.source.helm.parameters[] | select(.name == "image.tag").value')
+          ./argocd --grpc-web --auth-token $ARGOCD_TOKEN --server $ARGOCD_SERVER app patch ${{ inputs.service-identifier }}-${{ inputs.stage }} --patch='[{"op": "replace", "path": "/spec/info/0", "value": {"name": "Source Code Diff", "value": "'"https://github.com/${{ github.repository }}/compare/${OLD_TAG::8}...${GITHUB_SHA::8}"'"}}]'
+          ./argocd --grpc-web --auth-token $ARGOCD_TOKEN --server $ARGOCD_SERVER app set argocd/${{ inputs.service-identifier }}-${{ inputs.stage }} -p kotlin.revision=${GITHUB_SHA::8} -p kotlin.build=${{ github.run_number }} -p kotlin.image.tag=${GITHUB_SHA}
       - name: Publish result message to slack
         uses: monta-app/slack-notifier-cli-action@main
         if: always()

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -131,7 +131,7 @@ jobs:
         shell: bash
         run: |
           if [ "${{ secrets.ARGOCD_TOKEN }}" == '' ]; then
-            echo "MUST INPUT ARGOCD_TOKEN SECRET"
+            echo "::error::MUST INPUT ARGOCD_TOKEN SECRET"
             echo "ARGOCD_TOKEN_STAGING / ARGOCD_TOKEN_PRODUCTION"
             exit 1
           fi
@@ -157,7 +157,7 @@ jobs:
           ARGOCD_SERVER: ${{ steps.set-argocd-server.outputs.argocd-hostname }}
         run: |
           if [ "${{ secrets.ARGOCD_TOKEN }}" == '' ]; then
-            echo "MUST INPUT ARGOCD_TOKEN SECRET"
+            echo "::error::MUST INPUT ARGOCD_TOKEN SECRET"
             echo "ARGOCD_TOKEN_STAGING / ARGOCD_TOKEN_PRODUCTION"
             exit 1
           fi

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -91,9 +91,8 @@ on:
         required: true
         description: 'Slack app token'
       ARGOCD_TOKEN:
-        required: false
+        required: false # REQUIRED WHEN USING `upload-open-api`!!!
         description: 'ArgoCD token'
-
 permissions:
   id-token: write # This is required for requesting the JWT
   contents: read
@@ -108,6 +107,7 @@ jobs:
     outputs:
       slack-message-id: ${{ steps.publish-slack.outputs.slack-message-id }}
       runners: ${{ toJSON(steps.*.outputs.runner) }}
+      service-cluster: ${{ steps.get-manifest-info.outputs.cluster }}
       service-namespace: ${{ steps.get-manifest-info.outputs.namespace }}
       service-name: ${{ steps.get-manifest-info.outputs.service-name }}
     steps:
@@ -142,6 +142,11 @@ jobs:
           fi
           curl -sSL -o argocd https://github.com/argoproj/argo-cd/releases/latest/download/argocd-linux-amd64
           sudo chmod +x argocd
+          K8S_CLUSTER=$(./argocd --auth-token $ARGOCD_TOKEN --server ${{ inputs.argocd-server }} app get argocd/${{ inputs.service-identifier }}-${{ inputs.stage }} -o yaml | yq '.spec.destination.cluster')
+          if [ $K8S_CLUSTER == "main-prod" ]; then
+            export K8S_CLUSTER="main-production"
+          fi
+          echo "cluster=$K8S_CLUSTER" >> "$GITHUB_OUTPUT"
           K8S_NAMESPACE=$(./argocd --auth-token $ARGOCD_TOKEN --server ${{ inputs.argocd-server }} app get argocd/${{ inputs.service-identifier }}-${{ inputs.stage }} -o yaml | yq '.spec.destination.namespace')
           echo "namespace=$K8S_NAMESPACE" >> "$GITHUB_OUTPUT"
           SERVICE_NAME=$(./argocd --auth-token $ARGOCD_TOKEN --server ${{ inputs.argocd-server }} app manifests argocd/${{ inputs.service-identifier }}-${{ inputs.stage }} | yq 'select(di == 1) | .metadata.labels."app.kubernetes.io/name"')
@@ -335,7 +340,7 @@ jobs:
   update-open-api-spec:
     if: ${{ inputs.upload-open-api }}
     name: Update OpenAPI Spec
-    needs: [ build, test ]
+    needs: [ init ]
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -351,6 +356,21 @@ jobs:
         shell: bash
         run: |
           curl --proto '=https' --tlsv1.2 -sSfL https://run.linkerd.io/install | sh
+      - name: Install kubectl CLI
+        shell: bash
+        run: |
+          curl -LO https://dl.k8s.io/release/v1.28.4/bin/linux/amd64/kubectl
+          sudo chmod +x kubectl
+      - name: Install Teleport
+        uses: teleport-actions/setup@v1
+        with:
+          version: 14.1.0
+      - name: Authorize against Teleport
+        uses: teleport-actions/auth-k8s@v2
+        with:
+          proxy: 'teleport.monta.app:443'
+          token: github-actions
+          kubernetes-cluster: ${{ needs.init.outputs.service-cluster }}
       - name: Update Path with LinkerD CLI
         shell: bash
         run: |
@@ -372,8 +392,8 @@ jobs:
         shell: bash
         env:
           GRADLE_MODULE: ${{ inputs.gradle-module }}
-          K8S_NAMESPACE: ${{ needs.get-manifest-info.outputs.service-namespace }}
-          SERVICE_NAME: ${{ needs.get-manifest-info.outputs.service-name }}
+          K8S_NAMESPACE: ${{ needs.init.outputs.service-namespace }}
+          SERVICE_NAME: ${{ needs.init.outputs.service-name }}
         run: |
           # Hardcoded target directory
           TARGET_DIR="build/tmp/kapt3/classes/main/META-INF/swagger"
@@ -402,34 +422,7 @@ jobs:
 
           linkerd profile --ignore-cluster -n $K8S_NAMESPACE --open-api $YML_FILE $SERVICE_NAME >> service-profile.yaml
 
-          SERVICE_PROFILE=$(realpath service-profile.yaml)
-          echo "Service Profile path $SERVICE_PROFILE"
-          echo "service-profile-path=$SERVICE_PROFILE" >> "$GITHUB_OUTPUT"
-
-      - name: Generate commit info
-        id: generate-commit-info
-        shell: bash
-        env:
-          SERVICE_IDENTIFIER: ${{ inputs.service-identifier }}
-          STAGE: ${{ inputs.stage }}
-        run: |
-          DESTINATION_PATH="apps/${SERVICE_IDENTIFIER}/${STAGE}/app/templates"
-          echo "Destination path $DESTINATION_PATH"
-          echo "destination-path=$DESTINATION_PATH" >> "$GITHUB_OUTPUT"
-          COMMIT_MESSAGE="chore($SERVICE_IDENTIFIER): updated open API spec for $STAGE"
-          echo "Commit message $COMMIT_MESSAGE"
-          echo "commit-message=$COMMIT_MESSAGE" >> "$GITHUB_OUTPUT"
-      - name: Push service profile to repository
-        uses: dmnemec/copy_file_to_another_repo_action@main
-        env:
-          API_TOKEN_GITHUB: ${{ secrets.MANIFEST_REPO_PAT }}
-        with:
-          source_file: ${{ steps.create-service-profile.outputs.service-profile-path }}
-          destination_repo: 'monta-app/kube-manifests'
-          destination_folder: ${{ steps.generate-commit-info.outputs.destination-path }}
-          user_email: "action@github.com"
-          user_name: "GitHub Action"
-          commit_message: ${{ steps.generate-commit-info.outputs.commit-message }}
+          kubectl -n $K8S_NAMESPACE apply -f service-profile.yaml
 
   push-manifest-list:
     name: Push Manifest

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -127,12 +127,6 @@ jobs:
       - id: arm64
         if: ${{ inputs.arm-build }}
         run: echo "runner=self-hosted-arm64" >> $GITHUB_OUTPUT
-      - name: Check out manifest repository
-        if: ${{ inputs.upload-open-api }}
-        uses: actions/checkout@v3
-        with:
-          repository: monta-app/kube-manifests
-          token: ${{ secrets.MANIFEST_REPO_PAT }}
       - name: Get manifest info
         id: get-manifest-info
         if: ${{ inputs.upload-open-api }}
@@ -140,12 +134,17 @@ jobs:
         env:
           SERVICE_IDENTIFIER: ${{ inputs.service-identifier }}
           STAGE: ${{ inputs.stage }}
+          ARGOCD_TOKEN: ${{ secrets.ARGOCD_TOKEN }}
         run: |
-          # Read namespace from config.yaml
-          K8S_NAMESPACE=$(cat apps/$SERVICE_IDENTIFIER/$STAGE/cluster/config.yaml | yq '.namespace')
+          if [ "${{ secrets.ARGOCD_TOKEN }}" == '' ]; then
+            echo "MUST INPUT ARGOCD_TOKEN SECRET"
+            exit 1
+          fi
+          curl -sSL -o argocd https://github.com/argoproj/argo-cd/releases/latest/download/argocd-linux-amd64
+          sudo chmod +x argocd
+          K8S_NAMESPACE=$(./argocd --auth-token $ARGOCD_TOKEN --server ${{ inputs.argocd-server }} app get argocd/${{ inputs.service-identifier }}-${{ inputs.stage }} -o yaml | yq '.spec.destination.namespace')
           echo "namespace=$K8S_NAMESPACE" >> "$GITHUB_OUTPUT"
-          # Read service name from values.yaml
-          SERVICE_NAME=$(cat apps/$SERVICE_IDENTIFIER/$STAGE/app/values.yaml | yq '.[] | select(key == "laravel" or key == "kotlin").fullnameOverride')
+          SERVICE_NAME=$(./argocd --auth-token $ARGOCD_TOKEN --server ${{ inputs.argocd-server }} app manifests argocd/${{ inputs.service-identifier }}-${{ inputs.stage }} | yq 'select(di == 1) | .metadata.labels."app.kubernetes.io/name"')
           echo "service-name=$SERVICE_NAME" >> "$GITHUB_OUTPUT"
 
   test:

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -206,6 +206,93 @@ jobs:
           slack-channel-id: ${{ inputs.slack-channel-id }}
           slack-message-id: ${{ needs.init.outputs.slack-message-id }}
 
+  update-open-api-spec:
+    if: ${{ inputs.upload-open-api }}
+    name: Update OpenAPI Spec
+    needs: [ init, test, build ]
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Set up JDK
+        uses: actions/setup-java@v3
+        with:
+          distribution: ${{ inputs.java-distribution }}
+          java-version: ${{ inputs.java-version }}
+          cache: 'gradle'
+      - name: Install LinkerD CLI
+        shell: bash
+        run: |
+          curl --proto '=https' --tlsv1.2 -sSfL https://run.linkerd.io/install | sh
+      - name: Install kubectl CLI
+        shell: bash
+        run: |
+          curl -LO https://dl.k8s.io/release/v1.28.4/bin/linux/amd64/kubectl
+          sudo chmod +x kubectl
+      - name: Install Teleport
+        uses: teleport-actions/setup@v1
+        with:
+          version: 14.1.5
+      - name: Authorize against Teleport
+        uses: teleport-actions/auth-k8s@v2
+        with:
+          proxy: 'teleport.monta.app:443'
+          token: github-actions
+          kubernetes-cluster: ${{ needs.init.outputs.service-cluster }}
+      - name: Update Path with LinkerD CLI
+        shell: bash
+        run: |
+          echo "/home/runner/.linkerd2/bin" >> $GITHUB_PATH
+      - name: Build Open API Spec
+        shell: bash
+        env:
+          GHL_USERNAME: ${{ secrets.GHL_USERNAME }}
+          GHL_PASSWORD: ${{ secrets.GHL_PASSWORD }}
+          GRADLE_MODULE: ${{ inputs.gradle-module }}
+        run: |
+          if [ -n "$GRADLE_MODULE" ]; then
+              ./gradlew $GRADLE_MODULE:kaptKotlin
+          else
+              ./gradlew kaptKotlin
+          fi
+      - name: Create service profile
+        id: create-service-profile
+        shell: bash
+        env:
+          GRADLE_MODULE: ${{ inputs.gradle-module }}
+          K8S_NAMESPACE: ${{ needs.init.outputs.service-namespace }}
+          SERVICE_NAME: ${{ needs.init.outputs.service-name }}
+        run: |
+          # Hardcoded target directory
+          TARGET_DIR="build/tmp/kapt3/classes/main/META-INF/swagger"
+
+          # Check if a gradle-module parameter is supplied and if so, prepend it to the target directory
+          if [ -n "$GRADLE_MODULE" ]; then
+              TARGET_DIR="${GRADLE_MODULE}/${TARGET_DIR}"
+          fi
+
+          # Ensure the target directory exists
+          if [ ! -d "${TARGET_DIR}" ]; then
+              echo "Error: Target directory '${TARGET_DIR}' does not exist."
+              exit 1
+          fi
+
+          cd $TARGET_DIR
+
+          # Find the first .yml file in the target directory
+          YML_FILE=$(find . -type f -name '*.yml' | head -n 1)
+
+          # Check if a .yml file was found and display the result or an error message
+          if [ -z "${YML_FILE}" ]; then
+              echo "No .yml file found in ${TARGET_DIR}."
+              exit 1
+          fi
+
+          linkerd profile --ignore-cluster -n $K8S_NAMESPACE --open-api $YML_FILE $SERVICE_NAME >> service-profile.yaml
+
+          kubectl -n $K8S_NAMESPACE apply -f service-profile.yaml
+
   build:
     name: Build
     needs: init
@@ -336,93 +423,6 @@ jobs:
           slack-app-token: ${{ secrets.SLACK_APP_TOKEN }}
           slack-channel-id: ${{ inputs.slack-channel-id }}
           slack-message-id: ${{ needs.init.outputs.slack-message-id }}
-
-  update-open-api-spec:
-    if: ${{ inputs.upload-open-api }}
-    name: Update OpenAPI Spec
-    needs: [ init, test, build ]
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-      - name: Set up JDK
-        uses: actions/setup-java@v3
-        with:
-          distribution: ${{ inputs.java-distribution }}
-          java-version: ${{ inputs.java-version }}
-          cache: 'gradle'
-      - name: Install LinkerD CLI
-        shell: bash
-        run: |
-          curl --proto '=https' --tlsv1.2 -sSfL https://run.linkerd.io/install | sh
-      - name: Install kubectl CLI
-        shell: bash
-        run: |
-          curl -LO https://dl.k8s.io/release/v1.28.4/bin/linux/amd64/kubectl
-          sudo chmod +x kubectl
-      - name: Install Teleport
-        uses: teleport-actions/setup@v1
-        with:
-          version: 14.1.5
-      - name: Authorize against Teleport
-        uses: teleport-actions/auth-k8s@v2
-        with:
-          proxy: 'teleport.monta.app:443'
-          token: github-actions
-          kubernetes-cluster: ${{ needs.init.outputs.service-cluster }}
-      - name: Update Path with LinkerD CLI
-        shell: bash
-        run: |
-          echo "/home/runner/.linkerd2/bin" >> $GITHUB_PATH
-      - name: Build Open API Spec
-        shell: bash
-        env:
-          GHL_USERNAME: ${{ secrets.GHL_USERNAME }}
-          GHL_PASSWORD: ${{ secrets.GHL_PASSWORD }}
-          GRADLE_MODULE: ${{ inputs.gradle-module }}
-        run: |
-          if [ -n "$GRADLE_MODULE" ]; then
-              ./gradlew $GRADLE_MODULE:kaptKotlin
-          else
-              ./gradlew kaptKotlin
-          fi
-      - name: Create service profile
-        id: create-service-profile
-        shell: bash
-        env:
-          GRADLE_MODULE: ${{ inputs.gradle-module }}
-          K8S_NAMESPACE: ${{ needs.init.outputs.service-namespace }}
-          SERVICE_NAME: ${{ needs.init.outputs.service-name }}
-        run: |
-          # Hardcoded target directory
-          TARGET_DIR="build/tmp/kapt3/classes/main/META-INF/swagger"
-
-          # Check if a gradle-module parameter is supplied and if so, prepend it to the target directory
-          if [ -n "$GRADLE_MODULE" ]; then
-              TARGET_DIR="${GRADLE_MODULE}/${TARGET_DIR}"
-          fi
-
-          # Ensure the target directory exists
-          if [ ! -d "${TARGET_DIR}" ]; then
-              echo "Error: Target directory '${TARGET_DIR}' does not exist."
-              exit 1
-          fi
-
-          cd $TARGET_DIR
-
-          # Find the first .yml file in the target directory
-          YML_FILE=$(find . -type f -name '*.yml' | head -n 1)
-
-          # Check if a .yml file was found and display the result or an error message
-          if [ -z "${YML_FILE}" ]; then
-              echo "No .yml file found in ${TARGET_DIR}."
-              exit 1
-          fi
-
-          linkerd profile --ignore-cluster -n $K8S_NAMESPACE --open-api $YML_FILE $SERVICE_NAME >> service-profile.yaml
-
-          kubectl -n $K8S_NAMESPACE apply -f service-profile.yaml
 
   push-manifest-list:
     name: Push Manifest

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -340,7 +340,7 @@ jobs:
   update-open-api-spec:
     if: ${{ inputs.upload-open-api }}
     name: Update OpenAPI Spec
-    needs: [ init ]
+    needs: [ init, test, build ]
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -64,10 +64,6 @@ on:
         type: boolean
         default: true
         description: 'If false, will use ArgoCD Updater instead of pushing to kube-manifests'
-      argocd-server:
-        required: false
-        type: string
-        description: 'ArgoCD hostname'
     secrets:
       GHL_USERNAME:
         required: true
@@ -92,7 +88,7 @@ on:
         description: 'Slack app token'
       ARGOCD_TOKEN:
         required: false # REQUIRED WHEN USING `upload-open-api`!!!
-        description: 'ArgoCD token'
+        description: 'ArgoCD token - should be set to ARGOCD_TOKEN_STAGING / ARGOCD_TOKEN_PRODUCTION'
 permissions:
   id-token: write # This is required for requesting the JWT
   contents: read
@@ -103,6 +99,8 @@ jobs:
   init:
     name: Sending first Slack message
     runs-on: ubuntu-latest
+    env:
+      argocd-token: ${{ secrets.ARGOCD_TOKEN }}
     timeout-minutes: 5
     outputs:
       slack-message-id: ${{ steps.publish-slack.outputs.slack-message-id }}
@@ -110,6 +108,7 @@ jobs:
       service-cluster: ${{ steps.get-manifest-info.outputs.cluster }}
       service-namespace: ${{ steps.get-manifest-info.outputs.namespace }}
       service-name: ${{ steps.get-manifest-info.outputs.service-name }}
+      argocd-server: ${{ steps.set-argocd-server.outputs.argocd-hostname }}
     steps:
       - name: Publish progress message to slack
         uses: monta-app/slack-notifier-cli-action@main
@@ -127,6 +126,26 @@ jobs:
       - id: arm64
         if: ${{ inputs.arm-build }}
         run: echo "runner=self-hosted-arm64" >> $GITHUB_OUTPUT
+      - id: verify-argocd-token
+        if: ${{ ! inputs.push-to-manifests }}
+        shell: bash
+        run: |
+          if [ "${{ secrets.ARGOCD_TOKEN }}" == '' ]; then
+            echo "MUST INPUT ARGOCD_TOKEN SECRET"
+            echo "ARGOCD_TOKEN_STAGING / ARGOCD_TOKEN_PRODUCTION"
+            exit 1
+          fi
+      - id: set-argocd-server
+        if: ${{ env.argocd-token != '' }}
+        env:
+          STAGE: ${{ inputs.stage }}
+        run: |
+          if [[ $STAGE =~ dev|staging ]]; then
+            ARGOCD_HOSTNAME="argocd.staging.monta.app"
+          else
+            ARGOCD_HOSTNAME="argocd.monta.app"
+          fi
+          echo "argocd-hostname=$ARGOCD_HOSTNAME" >> "$GITHUB_OUTPUT"
       - name: Get manifest info
         id: get-manifest-info
         if: ${{ inputs.upload-open-api }}
@@ -135,22 +154,35 @@ jobs:
           SERVICE_IDENTIFIER: ${{ inputs.service-identifier }}
           STAGE: ${{ inputs.stage }}
           ARGOCD_TOKEN: ${{ secrets.ARGOCD_TOKEN }}
+          ARGOCD_SERVER: ${{ steps.set-argocd-server.outputs.argocd-hostname }}
         run: |
           if [ "${{ secrets.ARGOCD_TOKEN }}" == '' ]; then
             echo "MUST INPUT ARGOCD_TOKEN SECRET"
+            echo "ARGOCD_TOKEN_STAGING / ARGOCD_TOKEN_PRODUCTION"
             exit 1
           fi
           curl -sSL -o argocd https://github.com/argoproj/argo-cd/releases/latest/download/argocd-linux-amd64
           sudo chmod +x argocd
-          K8S_CLUSTER=$(./argocd --auth-token $ARGOCD_TOKEN --server ${{ inputs.argocd-server }} app get argocd/${{ inputs.service-identifier }}-${{ inputs.stage }} -o yaml | yq '.spec.destination.cluster')
+          K8S_CLUSTER=$(./argocd --auth-token $ARGOCD_TOKEN --server $ARGOCD_SERVER app get argocd/${{ inputs.service-identifier }}-${{ inputs.stage }} -o yaml | yq '.spec.destination.cluster')
           if [ $K8S_CLUSTER == "main-prod" ]; then
             export K8S_CLUSTER="main-production"
           fi
           echo "cluster=$K8S_CLUSTER" >> "$GITHUB_OUTPUT"
-          K8S_NAMESPACE=$(./argocd --auth-token $ARGOCD_TOKEN --server ${{ inputs.argocd-server }} app get argocd/${{ inputs.service-identifier }}-${{ inputs.stage }} -o yaml | yq '.spec.destination.namespace')
+          K8S_NAMESPACE=$(./argocd --auth-token $ARGOCD_TOKEN --server $ARGOCD_SERVER app get argocd/${{ inputs.service-identifier }}-${{ inputs.stage }} -o yaml | yq '.spec.destination.namespace')
           echo "namespace=$K8S_NAMESPACE" >> "$GITHUB_OUTPUT"
-          SERVICE_NAME=$(./argocd --auth-token $ARGOCD_TOKEN --server ${{ inputs.argocd-server }} app manifests argocd/${{ inputs.service-identifier }}-${{ inputs.stage }} | yq 'select(di == 1) | .metadata.labels."app.kubernetes.io/name"')
+          SERVICE_NAME=$(./argocd --auth-token $ARGOCD_TOKEN --server $ARGOCD_SERVER app manifests argocd/${{ inputs.service-identifier }}-${{ inputs.stage }} | yq 'select(di == 1) | .metadata.labels."app.kubernetes.io/name"')
           echo "service-name=$SERVICE_NAME" >> "$GITHUB_OUTPUT"
+      - name: Publish result message to slack
+        uses: monta-app/slack-notifier-cli-action@main
+        if: failure()
+        with:
+          job-type: "test"
+          job-status: ${{ job.status }}
+          service-name: ${{ inputs.service-name }}
+          service-emoji: ${{ inputs.service-emoji }}
+          slack-app-token: ${{ secrets.SLACK_APP_TOKEN }}
+          slack-channel-id: ${{ inputs.slack-channel-id }}
+          slack-message-id: ${{ steps.publish-slack.outputs.slack-message-id }}
 
   test:
     name: Test
@@ -583,10 +615,11 @@ jobs:
         shell: bash
         env:
           ARGOCD_TOKEN: ${{ secrets.ARGOCD_TOKEN }}
+          ARGOCD_SERVER: ${{ needs.init.outputs.argocd-server }}
         run: |
-          OLD_TAG=$(./argocd --auth-token $ARGOCD_TOKEN --server ${{ inputs.argocd-server }} app get argocd/${{ inputs.service-identifier }}-${{ inputs.stage }} --show-params -o yaml | yq -e=0 '.spec.source.helm.parameters[] | select(.name == "image.tag").value')
-          ./argocd --auth-token $ARGOCD_TOKEN --server ${{ inputs.argocd-server }} app patch ${{ inputs.service-identifier }}-${{ inputs.stage }} --patch='[{"op": "replace", "path": "/spec/info/0", "value": {"name": "Source Code Diff", "value": "'"https://github.com/${{ github.repository }}/compare/${OLD_TAG::8}...${GITHUB_SHA::8}"'"}}]'
-          ./argocd --auth-token $ARGOCD_TOKEN --server ${{ inputs.argocd-server }} app set argocd/${{ inputs.service-identifier }}-${{ inputs.stage }} -p kotlin.revision=${GITHUB_SHA::8} -p kotlin.build=${{ github.run_number }} -p kotlin.image.tag=${GITHUB_SHA}
+          OLD_TAG=$(./argocd --auth-token $ARGOCD_TOKEN --server $ARGOCD_SERVER app get argocd/${{ inputs.service-identifier }}-${{ inputs.stage }} --show-params -o yaml | yq -e=0 '.spec.source.helm.parameters[] | select(.name == "image.tag").value')
+          ./argocd --auth-token $ARGOCD_TOKEN --server $ARGOCD_SERVER app patch ${{ inputs.service-identifier }}-${{ inputs.stage }} --patch='[{"op": "replace", "path": "/spec/info/0", "value": {"name": "Source Code Diff", "value": "'"https://github.com/${{ github.repository }}/compare/${OLD_TAG::8}...${GITHUB_SHA::8}"'"}}]'
+          ./argocd --auth-token $ARGOCD_TOKEN --server $ARGOCD_SERVER app set argocd/${{ inputs.service-identifier }}-${{ inputs.stage }} -p kotlin.revision=${GITHUB_SHA::8} -p kotlin.build=${{ github.run_number }} -p kotlin.image.tag=${GITHUB_SHA}
       - name: Publish result message to slack
         uses: monta-app/slack-notifier-cli-action@main
         if: always()

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -364,7 +364,7 @@ jobs:
       - name: Install Teleport
         uses: teleport-actions/setup@v1
         with:
-          version: 14.1.0
+          version: 14.1.5
       - name: Authorize against Teleport
         uses: teleport-actions/auth-k8s@v2
         with:

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -108,6 +108,8 @@ jobs:
     outputs:
       slack-message-id: ${{ steps.publish-slack.outputs.slack-message-id }}
       runners: ${{ toJSON(steps.*.outputs.runner) }}
+      service-namespace: ${{ steps.get-manifest-info.outputs.namespace }}
+      service-name: ${{ steps.get-manifest-info.outputs.service-name }}
     steps:
       - name: Publish progress message to slack
         uses: monta-app/slack-notifier-cli-action@main
@@ -125,6 +127,26 @@ jobs:
       - id: arm64
         if: ${{ inputs.arm-build }}
         run: echo "runner=self-hosted-arm64" >> $GITHUB_OUTPUT
+      - name: Check out manifest repository
+        if: ${{ inputs.upload-open-api }}
+        uses: actions/checkout@v3
+        with:
+          repository: monta-app/kube-manifests
+          token: ${{ secrets.MANIFEST_REPO_PAT }}
+      - name: Get manifest info
+        id: get-manifest-info
+        if: ${{ inputs.upload-open-api }}
+        shell: bash
+        env:
+          SERVICE_IDENTIFIER: ${{ inputs.service-identifier }}
+          STAGE: ${{ inputs.stage }}
+        run: |
+          # Read namespace from config.yaml
+          K8S_NAMESPACE=$(cat apps/$SERVICE_IDENTIFIER/$STAGE/cluster/config.yaml | yq '.namespace')
+          echo "namespace=$K8S_NAMESPACE" >> "$GITHUB_OUTPUT"
+          # Read service name from values.yaml
+          SERVICE_NAME=$(cat apps/$SERVICE_IDENTIFIER/$STAGE/app/values.yaml | yq '.[] | select(key == "laravel" or key == "kotlin").fullnameOverride')
+          echo "service-name=$SERVICE_NAME" >> "$GITHUB_OUTPUT"
 
   test:
     name: Test
@@ -179,133 +201,6 @@ jobs:
           slack-app-token: ${{ secrets.SLACK_APP_TOKEN }}
           slack-channel-id: ${{ inputs.slack-channel-id }}
           slack-message-id: ${{ needs.init.outputs.slack-message-id }}
-
-  get-manifest-info:
-    if: ${{ inputs.upload-open-api }}
-    name: Get manifest information
-    needs: [ test ]
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    outputs:
-      service-namespace: ${{ steps.get-manifest-info.outputs.namespace }}
-      service-name: ${{ steps.get-manifest-info.outputs.service-name }}
-    steps:
-      - name: Check out manifest repository
-        uses: actions/checkout@v3
-        with:
-          repository: monta-app/kube-manifests
-          token: ${{ secrets.MANIFEST_REPO_PAT }}
-      - name: Get manifest info
-        id: get-manifest-info
-        shell: bash
-        env:
-          SERVICE_IDENTIFIER: ${{ inputs.service-identifier }}
-          STAGE: ${{ inputs.stage }}
-        run: |
-          # Read namespace from config.yaml
-          K8S_NAMESPACE=$(cat apps/$SERVICE_IDENTIFIER/$STAGE/cluster/config.yaml | yq '.namespace')
-          echo "namespace=$K8S_NAMESPACE" >> "$GITHUB_OUTPUT"
-          # Read service name from values.yaml
-          SERVICE_NAME=$(cat apps/$SERVICE_IDENTIFIER/$STAGE/app/values.yaml | yq '.[] | select(key == "laravel" or key == "kotlin").fullnameOverride')
-          echo "service-name=$SERVICE_NAME" >> "$GITHUB_OUTPUT"
-  update-open-api-spec:
-    if: ${{ inputs.upload-open-api }}
-    name: Update OpenAPI Spec
-    needs: [ get-manifest-info ]
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-      - name: Set up JDK
-        uses: actions/setup-java@v3
-        with:
-          distribution: ${{ inputs.java-distribution }}
-          java-version: ${{ inputs.java-version }}
-          cache: 'gradle'
-      - name: Install LinkerD CLI
-        shell: bash
-        run: |
-          curl --proto '=https' --tlsv1.2 -sSfL https://run.linkerd.io/install | sh
-      - name: Update Path with LinkerD CLI
-        shell: bash
-        run: |
-          echo "/home/runner/.linkerd2/bin" >> $GITHUB_PATH
-      - name: Build Open API Spec
-        shell: bash
-        env:
-          GHL_USERNAME: ${{ secrets.GHL_USERNAME }}
-          GHL_PASSWORD: ${{ secrets.GHL_PASSWORD }}
-          GRADLE_MODULE: ${{ inputs.gradle-module }}
-        run: |
-          if [ -n "$GRADLE_MODULE" ]; then
-              ./gradlew $GRADLE_MODULE:kaptKotlin
-          else
-              ./gradlew kaptKotlin
-          fi
-      - name: Create service profile
-        id: create-service-profile
-        shell: bash
-        env:
-          GRADLE_MODULE: ${{ inputs.gradle-module }}
-          K8S_NAMESPACE: ${{ needs.get-manifest-info.outputs.service-namespace }}
-          SERVICE_NAME: ${{ needs.get-manifest-info.outputs.service-name }}
-        run: |
-          # Hardcoded target directory
-          TARGET_DIR="build/tmp/kapt3/classes/main/META-INF/swagger"
-
-          # Check if a gradle-module parameter is supplied and if so, prepend it to the target directory
-          if [ -n "$GRADLE_MODULE" ]; then
-              TARGET_DIR="${GRADLE_MODULE}/${TARGET_DIR}"
-          fi
-
-          # Ensure the target directory exists
-          if [ ! -d "${TARGET_DIR}" ]; then
-              echo "Error: Target directory '${TARGET_DIR}' does not exist."
-              exit 1
-          fi
-
-          cd $TARGET_DIR
-
-          # Find the first .yml file in the target directory
-          YML_FILE=$(find . -type f -name '*.yml' | head -n 1)
-
-          # Check if a .yml file was found and display the result or an error message
-          if [ -z "${YML_FILE}" ]; then
-              echo "No .yml file found in ${TARGET_DIR}."
-              exit 1
-          fi
-
-          linkerd profile --ignore-cluster -n $K8S_NAMESPACE --open-api $YML_FILE $SERVICE_NAME >> service-profile.yaml
-
-          SERVICE_PROFILE=$(realpath service-profile.yaml)
-          echo "Service Profile path $SERVICE_PROFILE"
-          echo "service-profile-path=$SERVICE_PROFILE" >> "$GITHUB_OUTPUT"
-
-      - name: Generate commit info
-        id: generate-commit-info
-        shell: bash
-        env:
-          SERVICE_IDENTIFIER: ${{ inputs.service-identifier }}
-          STAGE: ${{ inputs.stage }}
-        run: |
-          DESTINATION_PATH="apps/${SERVICE_IDENTIFIER}/${STAGE}/app/templates"
-          echo "Destination path $DESTINATION_PATH"
-          echo "destination-path=$DESTINATION_PATH" >> "$GITHUB_OUTPUT"
-          COMMIT_MESSAGE="chore($SERVICE_IDENTIFIER): updated open API spec for $STAGE"
-          echo "Commit message $COMMIT_MESSAGE"
-          echo "commit-message=$COMMIT_MESSAGE" >> "$GITHUB_OUTPUT"
-      - name: Push service profile to repository
-        uses: dmnemec/copy_file_to_another_repo_action@main
-        env:
-          API_TOKEN_GITHUB: ${{ secrets.MANIFEST_REPO_PAT }}
-        with:
-          source_file: ${{ steps.create-service-profile.outputs.service-profile-path }}
-          destination_repo: 'monta-app/kube-manifests'
-          destination_folder: ${{ steps.generate-commit-info.outputs.destination-path }}
-          user_email: "action@github.com"
-          user_name: "GitHub Action"
-          commit_message: ${{ steps.generate-commit-info.outputs.commit-message }}
 
   build:
     name: Build
@@ -437,6 +332,105 @@ jobs:
           slack-app-token: ${{ secrets.SLACK_APP_TOKEN }}
           slack-channel-id: ${{ inputs.slack-channel-id }}
           slack-message-id: ${{ needs.init.outputs.slack-message-id }}
+
+  update-open-api-spec:
+    if: ${{ inputs.upload-open-api }}
+    name: Update OpenAPI Spec
+    needs: [ build, test ]
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Set up JDK
+        uses: actions/setup-java@v3
+        with:
+          distribution: ${{ inputs.java-distribution }}
+          java-version: ${{ inputs.java-version }}
+          cache: 'gradle'
+      - name: Install LinkerD CLI
+        shell: bash
+        run: |
+          curl --proto '=https' --tlsv1.2 -sSfL https://run.linkerd.io/install | sh
+      - name: Update Path with LinkerD CLI
+        shell: bash
+        run: |
+          echo "/home/runner/.linkerd2/bin" >> $GITHUB_PATH
+      - name: Build Open API Spec
+        shell: bash
+        env:
+          GHL_USERNAME: ${{ secrets.GHL_USERNAME }}
+          GHL_PASSWORD: ${{ secrets.GHL_PASSWORD }}
+          GRADLE_MODULE: ${{ inputs.gradle-module }}
+        run: |
+          if [ -n "$GRADLE_MODULE" ]; then
+              ./gradlew $GRADLE_MODULE:kaptKotlin
+          else
+              ./gradlew kaptKotlin
+          fi
+      - name: Create service profile
+        id: create-service-profile
+        shell: bash
+        env:
+          GRADLE_MODULE: ${{ inputs.gradle-module }}
+          K8S_NAMESPACE: ${{ needs.get-manifest-info.outputs.service-namespace }}
+          SERVICE_NAME: ${{ needs.get-manifest-info.outputs.service-name }}
+        run: |
+          # Hardcoded target directory
+          TARGET_DIR="build/tmp/kapt3/classes/main/META-INF/swagger"
+
+          # Check if a gradle-module parameter is supplied and if so, prepend it to the target directory
+          if [ -n "$GRADLE_MODULE" ]; then
+              TARGET_DIR="${GRADLE_MODULE}/${TARGET_DIR}"
+          fi
+
+          # Ensure the target directory exists
+          if [ ! -d "${TARGET_DIR}" ]; then
+              echo "Error: Target directory '${TARGET_DIR}' does not exist."
+              exit 1
+          fi
+
+          cd $TARGET_DIR
+
+          # Find the first .yml file in the target directory
+          YML_FILE=$(find . -type f -name '*.yml' | head -n 1)
+
+          # Check if a .yml file was found and display the result or an error message
+          if [ -z "${YML_FILE}" ]; then
+              echo "No .yml file found in ${TARGET_DIR}."
+              exit 1
+          fi
+
+          linkerd profile --ignore-cluster -n $K8S_NAMESPACE --open-api $YML_FILE $SERVICE_NAME >> service-profile.yaml
+
+          SERVICE_PROFILE=$(realpath service-profile.yaml)
+          echo "Service Profile path $SERVICE_PROFILE"
+          echo "service-profile-path=$SERVICE_PROFILE" >> "$GITHUB_OUTPUT"
+
+      - name: Generate commit info
+        id: generate-commit-info
+        shell: bash
+        env:
+          SERVICE_IDENTIFIER: ${{ inputs.service-identifier }}
+          STAGE: ${{ inputs.stage }}
+        run: |
+          DESTINATION_PATH="apps/${SERVICE_IDENTIFIER}/${STAGE}/app/templates"
+          echo "Destination path $DESTINATION_PATH"
+          echo "destination-path=$DESTINATION_PATH" >> "$GITHUB_OUTPUT"
+          COMMIT_MESSAGE="chore($SERVICE_IDENTIFIER): updated open API spec for $STAGE"
+          echo "Commit message $COMMIT_MESSAGE"
+          echo "commit-message=$COMMIT_MESSAGE" >> "$GITHUB_OUTPUT"
+      - name: Push service profile to repository
+        uses: dmnemec/copy_file_to_another_repo_action@main
+        env:
+          API_TOKEN_GITHUB: ${{ secrets.MANIFEST_REPO_PAT }}
+        with:
+          source_file: ${{ steps.create-service-profile.outputs.service-profile-path }}
+          destination_repo: 'monta-app/kube-manifests'
+          destination_folder: ${{ steps.generate-commit-info.outputs.destination-path }}
+          user_email: "action@github.com"
+          user_name: "GitHub Action"
+          commit_message: ${{ steps.generate-commit-info.outputs.commit-message }}
 
   push-manifest-list:
     name: Push Manifest


### PR DESCRIPTION
# Changes

### Removed ArgoCD hostname input
- set dynamically based on `stage` input
- needed only when the token secret is set

### Verify ArgoCD token input
- if going to deploy by ArgoCD (instead of committing to kube-manifests) or if going to update OpenAPI spec, verify that the token exists

### Move `get manifest info` job to init
- Gets variables needed by ArgoCD instead of reading from files. Super important for the multi-repo setup

### Apply OpenAPI spec directly to K8s
- Uses Teleport to authenticate
- applies directly to k8s, no need to push to git

# BREAKING!!!

Requires all repos that currently use `upload-open-api` to provide the `ARGOCD_TOKEN` secret.
I will open PRs for all the repos that use it, providing the secret and deleting the `service-profile.yaml` file from their directories https://github.com/monta-app/kube-manifests/pull/903

Progess:

- [x] ocpp https://github.com/monta-app/service-ocpp/pull/1142
- [x] api-v2-partner-api https://github.com/monta-app/partner-api/pull/1150
- [x] integrations https://github.com/monta-app/service-integrations/pull/689
- [x] data-broker
- [x] grid