### PR TITLE
use ubuntu-latest for build x64 and tests

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -122,7 +122,7 @@ jobs:
           slack-channel-id: ${{ inputs.slack-channel-id }}
       # calculates whether should run also on arm
       - id: x64
-        run: echo "runner=self-hosted-x64" >> $GITHUB_OUTPUT
+        run: echo "runner=ubuntu-latest" >> $GITHUB_OUTPUT
       - id: arm64
         if: ${{ inputs.arm-build }}
         run: echo "runner=self-hosted-arm64" >> $GITHUB_OUTPUT
@@ -187,7 +187,7 @@ jobs:
   test:
     name: Test
     needs: init
-    runs-on: self-hosted-x64
+    runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
       - name: Download curl


### PR DESCRIPTION
Using self hosted doesn't make it cheaper, so might as well use hosted for faster performance, and just ARM will run on self-hosted in a scalable way