### PR TITLE
fix: Do a full `build` and not just `test` in the `pull-request.yaml`…

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -55,9 +55,9 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           if [ -z "$GRADLE_MODULE" ]; then
-            ./gradlew --no-daemon test
+            ./gradlew --no-daemon build
           else
-            ./gradlew --no-daemon $GRADLE_MODULE:test
+            ./gradlew --no-daemon $GRADLE_MODULE:build
           fi
         shell: bash
       - name: Upload test results

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:base"
+    "local>monta-app/renovate-config",
+    ":semanticCommitTypeAll(chore)"
   ]
 }


### PR DESCRIPTION
… target to ensure that we are running ktlint already on PR's and not only on release time.

E.g. this https://github.com/monta-app/library-micronaut/actions/runs/7501577590/job/20422485522 first failed when doing the release and not the PRs

Also update renovate config to use our standard config