### PR TITLE
feat: Introduce composite GH Actions (HOME-22)

### DIFF
--- a/deploy-k8s-argocd/action.yml
+++ b/deploy-k8s-argocd/action.yml
@@ -1,0 +1,87 @@
+name: 'Deploy to k8s cluster using ArgoCD'
+description: |
+  Deploy to k8s cluster using ArgoCD by settings the kotlin.image.tag attribute on the Helm chart. 
+
+inputs:
+  service-identifier:
+    description: 'k8s service/deploy name'
+    required: true
+  docker-image-tag:
+    description: 'Docker image tage to deploy'
+    required: true
+  environment:
+    description: 'Monta environment (prepend to the name)'
+    required: true
+  argocd-token:
+    description: 'Token for talking with ArgoCD server'
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: 'Validate inputs'
+      shell: bash
+      run: |
+        if [[ "${{ inputs.service-identifier }}" =~ ^[a-z0-9\-]{1,64}$ ]];
+        then
+          echo "Service to deploy: ${{ inputs.service-identifier }}";
+        else
+          echo "Invalid service identifier: ${{ inputs.service-identifier }}";
+          exit 1;
+        fi
+        if [[ "${{ inputs.docker-image-tag }}" =~ ^[a-f0-9]{40}$ ]];
+        then
+          echo "Docker image tag to deploy: ${{ inputs.docker-image-tag }}";
+        else
+          echo "Invalid docker image tag: ${{ inputs.docker-image-tag }}";
+          exit 1;
+        fi
+        if [[ "${{ inputs.environment }}" =~ ^(dev|staging|production)$ ]];
+        then
+          echo "Environment deploy to: ${{ inputs.environment }}";
+        else
+          echo "Invalid environment name: ${{ inputs.environment }}";
+          exit 1;
+        fi
+        if [ -z "${{ inputs.argocd-token }}" ]
+        then
+          echo "input argocd-token is empty, aborting.";
+          exit 1;
+        fi
+    - name: 'Set ArgoCD server endpoint'
+      id: set-argocd-server
+      env:
+        ENVIRONMENT: ${{ inputs.environment }}
+      shell: bash
+      run: |
+        if [[ $ENVIRONMENT =~ dev|staging ]]; then
+          ARGOCD_SERVER="argocd.staging.monta.app"
+        else
+          ARGOCD_SERVER="argocd.monta.app"
+        fi
+        echo "ARGOCD_SERVER=$ARGOCD_SERVER" >> $GITHUB_ENV
+
+    - name: 'Download ArgoCD CLI'
+      shell: bash
+      run: |
+        curl -sSL -o argocd https://github.com/argoproj/argo-cd/releases/latest/download/argocd-linux-amd64
+        sudo chmod +x argocd
+
+    - name: 'ArgoCD update application'
+      env:
+        ARGOCD_TOKEN: ${{ inputs.argocd-token }}
+      shell: bash
+      run: |
+        OLD_TAG=$(./argocd --grpc-web --auth-token $ARGOCD_TOKEN --server $ARGOCD_SERVER app get argocd/${{ inputs.service-identifier }}-${{ inputs.environment }} --show-params -o yaml | yq -e=0 '.spec.source.helm.parameters[] | select(.name == "kotlin.image.tag").value')
+        ./argocd --grpc-web \
+          --auth-token $ARGOCD_TOKEN \
+          --server $ARGOCD_SERVER app patch ${{ inputs.service-identifier }}-${{ inputs.environment }} \
+          --patch='[{"op": "replace", "path": "/spec/info/0", "value": {"name": "Source Code Diff", "value": "'"https://github.com/${{ github.repository }}/compare/${OLD_TAG::8}...${GITHUB_SHA::8}"'"}}]'
+        echo "Updating docker image tag from ${OLD_TAG} to ${{ inputs.docker-image-tag }}"
+        ./argocd --grpc-web \
+          --auth-token $ARGOCD_TOKEN \
+          --server $ARGOCD_SERVER \
+          app set argocd/${{ inputs.service-identifier }}-${{ inputs.environment }} \
+          -p kotlin.revision=${GITHUB_SHA::8} \
+          -p kotlin.build=${{ github.run_number }} \
+          -p kotlin.image.tag=${{ inputs.docker-image-tag }}

--- a/docker-build/action.yml
+++ b/docker-build/action.yml
@@ -1,0 +1,80 @@
+name: 'Docker build (using buildx)'
+description: |
+  Use the docker GHA to tag and build one docker image for multi platform support.
+  Apply various open container labels to ensure we can identity the origin of the image.
+
+inputs:
+  docker-file-name:
+    description: 'Docker file name'
+    required: false
+    default: 'Dockerfile'
+  docker-registry:
+    description: 'The Docker registry hostname for tagging the image with'
+    required: false
+    default: '229494932364.dkr.ecr.eu-west-1.amazonaws.com'
+  docker-image-namespace:
+    description: 'Vendor namespace for docker image name. Must contain trailing slash ("/").'
+    required: false
+    default: 'monta/'
+  docker-image-name:
+    description: 'Name of the docker image to build, without namespace. For example "solar".'
+    required: true
+  platforms:
+    description: 'Docker buildx platforms to target. Comma separated list without spaces.'
+    required: false
+    default: 'linux/amd64,linux/arm64'
+outputs:
+  docker-image:
+    description: 'Comma separated list of fully qualified docker manifest for the image(s).'
+    value: ${{ env.DOCKER_METADATA_OUTPUT_TAGS }}
+
+runs:
+  using: composite
+  steps:
+    - name: 'Set up QEMU'
+      uses: docker/setup-qemu-action@v3
+
+    - name: 'Set up Docker Buildx'
+      uses: docker/setup-buildx-action@v3
+      # For now, the local "load" does not support multiple platforms (manifests).
+      # with:
+      #   platforms: 'arm64'
+
+    # Ensure we tag our images with the various org.opencontainers.image.* labels.
+    - name: 'Docker prepare metadata and tags/labels'
+      id: docker-meta
+      uses: docker/metadata-action@v5
+      with:
+        images: ${{ inputs.docker-registry }}/${{ inputs.docker-image-namespace }}${{ inputs.docker-image-name }}
+        tags: |
+          type=sha,format=long,prefix=,suffix=-${{ runner.arch }}
+        flavor: |
+          latest=false
+          prefix=
+          suffix=
+      # For now, the local "load" does not support multiple platforms (manifests).
+      # env:
+      #   DOCKER_METADATA_ANNOTATIONS_LEVELS: manifest,index
+
+    - name: 'Docker Build'
+      id: docker-build
+      uses: docker/build-push-action@v5
+      with:
+        # For now, the local "load" does not support multiple platforms (manifests).
+        # platforms: ${{ inputs.platforms }}
+        context: .
+        file: ./${{ inputs.docker-file-name }}
+        push: false
+        # Load the build images into the local docker, so other jobs can refer to them.
+        load: true
+        no-cache: true
+        # For pruning built image on self-hosted runner based on this run's ID
+        labels: |
+          GITHUB_RUN_ID=${{ github.run_id }}
+          ${{ steps.docker-meta.outputs.labels }}
+        tags: ${{ steps.docker-meta.outputs.tags }}
+
+    - name: 'Docker inspect'
+      shell: bash
+      run: |
+        docker image inspect ${{ env.DOCKER_METADATA_OUTPUT_TAGS }}

--- a/docker-gradle-setup/README.md
+++ b/docker-gradle-setup/README.md
@@ -1,0 +1,10 @@
+# AWS ECR Authenticate and Docker Login
+
+## Requirements
+On the top-level workflow, this actions needs permission to write the id-token.
+```yaml
+# These permissions are needed to interact with GitHub's OIDC Token endpoint.
+permissions:
+  id-token: write
+  contents: read
+```

--- a/docker-gradle-setup/action.yml
+++ b/docker-gradle-setup/action.yml
@@ -1,0 +1,82 @@
+name: 'Docker, Java and Gradle setup and checkout'
+description: |
+  Prepares the Github Workflow for a repository with Kotlin/Gradle code, by installing and setting the Java version,
+  installing docker compose, authenticating docker for the Monta develop the ECR registry. It uses other 
+  Github Actions to install and validate the JVM and Gradle.
+
+inputs:
+#  aws-account-id:
+#    description: 'AWS account identifier (integer)'
+#    required: false
+#    default: '229494932364'
+  aws-region:
+    description: 'AWS region identifier (string) assume access in'
+    required: false
+    default: 'eu-west-1'
+#  aws-iam-role-to-assume:
+#    description: 'The IAM role to assume via STS'
+#    required: false
+#    default: 'ecr-put-image'
+  aws-access-key-id:
+    description: 'AWS Access Key ID.'
+    required: true
+  aws-secret-access-key:
+    description: 'AWS Secret Access Key.'
+    required: true
+  docker-registry-develop:
+    description: 'The Docker registry hostname for development environment'
+    required: false
+    default: ''
+  java-version:
+    description: 'Major version of Java to set as default.'
+    required: false
+    default: '17'
+  java-distribution:
+    description: 'The Java JVM distribution to install'
+    required: false
+    default: 'corretto'
+
+runs:
+  using: composite
+  steps:
+    - name: 'Set custom env variables'
+      shell: bash
+      run: |
+        echo "PR_NUMBER=${{ github.event.number }}" >> $GITHUB_ENV
+
+    - name: 'Set up Java Virtual Machine'
+      uses: actions/setup-java@v4
+      with:
+        distribution: ${{ inputs.java-distribution }}
+        java-version: ${{ inputs.java-version }}
+
+    - name: Install docker compose
+      uses: KengoTODA/actions-setup-docker-compose@v1
+      with:
+        version: 'latest'
+
+    - name: 'Configure AWS credentials via assumed role'
+      uses: aws-actions/configure-aws-credentials@v4
+      with:
+        aws-region: ${{ inputs.aws-region }}
+        aws-access-key-id: ${{ inputs.aws-access-key-id }}
+        aws-secret-access-key: ${{ inputs.aws-secret-access-key }}
+        # role-to-assume: arn:aws:iam::${{ inputs.aws-account-id }}:role/${{ inputs.aws-iam-role-to-assume }}
+
+    - name: 'Login to Amazon ECR'
+      id: login-ecr
+      uses: aws-actions/amazon-ecr-login@v2
+
+    - name: 'Validate Gradle wrapper'
+      uses: gradle/wrapper-validation-action@342dbebe7272035434f9baccc29a816ec6dd2c7b
+
+    - name: 'Restore Cache - Gradle packages'
+      uses: actions/cache/restore@v3
+      with:
+        path: |
+          ~/.gradle/caches
+          ~/.gradle/wrapper
+        key: ${{ runner.os }}-gradle-${{ github.repository }}-${{ hashFiles('buildSrc/**/Dependencies.kt', '**/*.gradle*', '**/gradle.properties', '**/gradle-wrapper.properties', '**/settings.gradle*') }}
+        restore-keys: |
+          ${{ runner.os }}-gradle-${{ github.repository }}
+          ${{ runner.os }}-gradle-

--- a/gradle-post-build/action.yml
+++ b/gradle-post-build/action.yml
@@ -1,0 +1,43 @@
+name: 'Gradle post-build actions'
+description: |
+  Saves the build gradle artifacts and publishes test reports.
+
+inputs:
+  github-token:
+    description: 'Github token to run publish of JUnit reports in'
+    required: true
+
+runs:
+  using: composite
+  steps:
+    # Remove some files from the Gradle cache, so they aren't cached by GitHub Actions.
+    # Restoring these files from a GitHub Actions cache might cause problems for future builds.
+    - name: 'Cleanup Gradle Cache'
+      shell: bash
+      run: |
+        rm -f ~/.gradle/caches/modules-2/modules-2.lock
+        rm -f ~/.gradle/caches/modules-2/gc.properties
+
+    # Save cache for the build to speed up later builds
+    - name: 'Save Cache - Gradle packages'
+      uses: actions/cache/save@v3
+      with:
+        path: |
+          ~/.gradle/caches
+          ~/.gradle/wrapper
+        key: ${{ runner.os }}-gradle-${{ github.repository }}-${{ hashFiles('buildSrc/**/Dependencies.kt', '**/*.gradle*', '**/gradle-wrapper.properties') }}
+
+    - name: 'Publish Test Report'
+      uses: mikepenz/action-junit-report@v4
+      if: success() || failure()
+      with:
+        token: ${{ inputs.github-token }}
+        report_paths: "**/build/test-results/test/TEST-*.xml"
+
+    - name: 'Publish Integration Test Report'
+      uses: mikepenz/action-junit-report@v4
+      if: success() || failure()
+      with:
+        token: ${{ inputs.github-token }}
+        check_name: "JUnit Integration-Test Report"
+        report_paths: "**/build/test-results/integrationTest/TEST-*.xml"


### PR DESCRIPTION
Composite actions allows the callers (service workflows or other workflows within this repository) greater flexibility as they can pick and choose what is needed and don't have to buy into one single way or building.

Specifically for kotlin services, it allows services to build their docker images before pushing them, insuring that images that are pushes are has been service-level integration-tested before they are available on the docker registry.

This is very early days and many things are missing, specifically:
 - Release notes
 - ArgoCD deployments
 - GHA tests for the actions
 
 