### PR TITLE
fix(openapi): Add GHL_ environment variables to task discovery

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -284,6 +284,8 @@ jobs:
       - name: Discover build properties
         shell: bash
         env:
+          GHL_USERNAME: ${{ secrets.GHL_USERNAME }}
+          GHL_PASSWORD: ${{ secrets.GHL_PASSWORD }}
           GRADLE_MODULE: ${{ inputs.gradle-module }}
         run: |
           GRADLE_TASK=$(./gradlew ${GRADLE_MODULE}:tasks --all | grep -E '(kaptKotlin|kspKotlin)' | head -n1)


### PR DESCRIPTION
Some builds require the environment variables to be present to be able to get a list of all available tasks.

For example: https://github.com/monta-app/service-i18n/actions/runs/7872965048/job/21479525846