### PR TITLE
fix: Only run pr title checker on pull request

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -27,6 +27,7 @@ on:
 jobs:
   pr_title_checker:
     name: PR title checker
+    if: ${{ github.event_name == 'pull_request' }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:


### PR DESCRIPTION
In Charges, we would like to run the pull request workflow on every push to develop since we are not always doing PRs. Therefore, even though the workflow is named "pull-request" it would be great to have extra safety for the PR Title Checker job so that it only runs if actually in a PR context.