### PR TITLE
fix(portal2-api): Change php base branch to staging

### DIFF
--- a/.github/workflows/it-test.yaml
+++ b/.github/workflows/it-test.yaml
@@ -30,7 +30,7 @@ on:
       php-branch:
         required: false
         type: string
-        default: "development"
+        default: "staging"
         description: 'gradle module to be built'
       java-distribution:
         required: false


### PR DESCRIPTION
Workflow fails on the step "Checkout PHP-Server" for example here: https://github.com/monta-app/partner-api/pull/1665

After development branch was deleted we can't use development as base-branch for php-server. Instead we should use staging branch as base branch.