### PR TITLE
feat: Add support for ! (for marking breaking changes)

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -33,7 +33,7 @@ jobs:
     steps:
       - uses: Slashgear/action-check-pr-title@v4.3.0
         with:
-          regexp: '^(\[(develop|development|staging)\]\s)?(build|chore|ci|docs|feat|feature|fix|perf|refactor|revert|style|test|release|ignore)(\([\w\- ]+\))?: (.+)'
+          regexp: '^(\[(develop|development|staging)\]\s)?(build|chore|ci|docs|feat|feature|fix|perf|refactor|revert|style|test|release|ignore)(\([\w\- ]+\))?!?: (.+)'
           helpMessage: "Example: 'feat(app-api): Add new vehicle integration (SERVER-123)'"
   test:
     name: Test


### PR DESCRIPTION
* as the per the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification (which is unavailable right now) the way to mark a breaking change is by appending ! to commit type - examples
  * `fix!:`
  * `feat!:`
* decided to place it after the optional part `()`
  * `fix(ocpp)!:`
  * `feat(ocpp)!:`