### PR TITLE
fix(deploy): Fix bug with incorrect if statement

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -264,6 +264,8 @@ jobs:
     needs: [ init, test, build ]
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    env:
+      techdocs_key: ${{ secrets.TECHDOCS_AWS_ACCESS_KEY_ID }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -321,7 +323,7 @@ jobs:
         run: |
           ./gradlew $GRADLE_TASK
       - name: Upload Open API Spec to S3 backstage bucket pls
-        if: ${{ secrets.TECHDOCS_AWS_ACCESS_KEY_ID != '' }}
+        if: ${{ env.techdocs_key != '' }}
         shell: bash
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.TECHDOCS_AWS_ACCESS_KEY_ID }}


### PR DESCRIPTION
PRevious would result in :
`The workflow is not valid. In .github/workflows/deploy_staging.yml (Line: 29, Col: 11): Error from called workflow monta-app/github-workflows/.github/workflows/deploy.yaml@v2 (Line: 324, Col: 13): Unrecognized named-value: 'secrets'. Located at position 1 within expression: secrets.TECHDOCS_AWS_ACCESS_KEY_ID != ''`