### PR TITLE
fix: allow overwriting artifacts so actions can be re-run

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -83,6 +83,7 @@ jobs:
             **/reports/tests/test
             /home/runner/.gradle/daemon/**/daemon-*.out.log
           retention-days: 2
+          overwrite: true
       - name: add coverage to PR
         id: jacoco
         uses: madrapps/jacoco-report@v1.6.1


### PR DESCRIPTION
See migration guide: https://github.com/actions/download-artifact/blob/main/docs/MIGRATION.md#overwriting-an-artifact

Should fix this: https://github.com/monta-app/partner-api/actions/runs/9580839702/job/26418822518?pr=1795
![image](https://github.com/monta-app/github-workflows/assets/668808/935c79f4-a3ab-4550-b290-48323e2b1b0c)
