### PR TITLE
fix: use head of PR instead of target branch for tests

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -42,6 +42,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
       - name: Set up JDK
         uses: actions/setup-java@v4
         with:


### PR DESCRIPTION
fix: use head of PR instead of target branch for tests

Currently it uses target branch for tests which can be super confusing, since you will see errors that are not reproducible locally (unless you merge with target already).

With this PR we are using the head commit fo the PR instead