### PR TITLE
fix: new gradle validation action path

### DIFF
--- a/docker-gradle-setup/action.yml
+++ b/docker-gradle-setup/action.yml
@@ -68,7 +68,7 @@ runs:
       uses: aws-actions/amazon-ecr-login@v2
 
     - name: 'Validate Gradle wrapper'
-      uses: gradle/actions/wrapper-validation@v3
+      uses: gradle/actions/wrapper-validation@88425854a36845f9c881450d9660b5fd46bee142
 
     - name: 'Restore Cache - Gradle packages'
       uses: actions/cache/restore@v4

--- a/docker-gradle-setup/action.yml
+++ b/docker-gradle-setup/action.yml
@@ -68,7 +68,7 @@ runs:
       uses: aws-actions/amazon-ecr-login@v2
 
     - name: 'Validate Gradle wrapper'
-      uses: gradle/actions/wrapper-validation@88425854a36845f9c881450d9660b5fd46bee142
+      uses: gradle/actions/wrapper-validation@v3
 
     - name: 'Restore Cache - Gradle packages'
       uses: actions/cache/restore@v4

--- a/docker-gradle-setup/action.yml
+++ b/docker-gradle-setup/action.yml
@@ -68,7 +68,7 @@ runs:
       uses: aws-actions/amazon-ecr-login@v2
 
     - name: 'Validate Gradle wrapper'
-      uses: gradle/wrapper-validation-action@88425854a36845f9c881450d9660b5fd46bee142
+      uses: gradle/actions/wrapper-validation@v3
 
     - name: 'Restore Cache - Gradle packages'
       uses: actions/cache/restore@v4

--- a/docker-gradle-setup/action.yml
+++ b/docker-gradle-setup/action.yml
@@ -68,7 +68,7 @@ runs:
       uses: aws-actions/amazon-ecr-login@v2
 
     - name: 'Validate Gradle wrapper'
-      uses: gradle/actions/wrapper-validation@v3
+      uses: gradle/actions/wrapper-validation@87bf5ca2eab41bc2978d93f6cb0603c36a44fd08
 
     - name: 'Restore Cache - Gradle packages'
       uses: actions/cache/restore@v4


### PR DESCRIPTION
The gradle wrapper validation action [has a new path](https://github.com/gradle/wrapper-validation-action?tab=readme-ov-file).