### PR TITLE
chore: add test results report for pull requests

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -96,3 +96,11 @@ jobs:
           min-coverage-changed-files: 70
           title: Code Coverage ${{ inputs.gradle-module }}
           update-comment: true
+      - name: Publish Test Results
+        uses: EnricoMi/publish-unit-test-result-action@v2
+        if: always()
+        with:
+          files: |
+            **/build/test-results/**/*.xml
+            **/build/test-results/**/*.trx
+            **/build/test-results/**/*.json


### PR DESCRIPTION
Adds a test results report on pull requests.

Github action: https://github.com/EnricoMi/publish-unit-test-result-action
Context: https://monta-app01.slack.com/archives/C04JANZMTQV/p1721294268190129