### PR TITLE
chore: parameterize pull request so it works with multiple coverage tools

### DIFF
--- a/.github/workflows/pull-request-kover.yaml
+++ b/.github/workflows/pull-request-kover.yaml
@@ -1,4 +1,4 @@
-name: Pull Request (with Kover)
+name: Build and test (Kover)
 on:
   workflow_call:
     inputs:
@@ -15,6 +15,15 @@ on:
         required: false
         type: string
         default: '17'
+      gradle-module:
+        required: false
+        type: string
+        description: "Name of the gradle module being tested - only needed if you want to test one module in a multi-module project"
+      sonarcloud:
+        required: false
+        type: boolean
+        default: false
+        description: "Upload report to SonarCloud (SONAR_TOKEN must be set)"
     secrets:
       GHL_USERNAME:
         required: true
@@ -23,7 +32,7 @@ on:
         required: true
         description: "Github Password (Gradle plugin)"
       SONAR_TOKEN:
-        required: true
+        required: false
         description: "SonarCloud token"
 jobs:
   pr_title_checker:
@@ -32,7 +41,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: Slashgear/action-check-pr-title@v4.3.0
+      - uses: Slashgear/action-check-pr-title@v4
         with:
           regexp: '^(\[(develop|development|staging)\]\s)?(build|chore|ci|docs|feat|feature|fix|perf|refactor|revert|style|test|release|ignore)(\([\w\- ]+\))?!?: (.+)'
           helpMessage: "Example: 'feat(app-api): Add new vehicle integration (SERVER-123)'"
@@ -41,8 +50,9 @@ jobs:
     runs-on: ${{ inputs.action-runner }}
     timeout-minutes: 30
     steps:
-      # Check out the code
-      - uses: actions/checkout@v4
+      # Checkout
+      - name: Checkout
+        uses: actions/checkout@v4
         with:
           # to check out the actual pull request commit, not the merge commit
           ref: ${{ github.event.pull_request.head.sha }}
@@ -56,20 +66,24 @@ jobs:
           cache: 'gradle'
       # Cache SonarCloud packages
       - name: Cache SonarCloud packages
+        if: inputs.sonarcloud
         uses: actions/cache@v4
         with:
           path: ~/.sonar/cache
           key: ${{ runner.os }}-sonar
           restore-keys: ${{ runner.os }}-sonar
-      # Run our tests with coverage
+      # Run tests with coverage
       - name: Run tests with coverage
         env:
           GHL_USERNAME: ${{ secrets.GHL_USERNAME }}
           GHL_PASSWORD: ${{ secrets.GHL_PASSWORD }}
-        run: ./gradlew test koverXmlReport koverHtmlReport --parallel
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        # set the gradle tasks respecting any gradle-module used as input
+        run: ./gradlew --no-daemon ${{ format('{0}:ktlintCheck {0}:koverXmlReport {0}:koverHtmlReport', inputs.gradle-module) }} --parallel
+        shell: bash
       # Upload test results
       - name: Upload test results
-        if: ${{ always() }}
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: test-result
@@ -81,19 +95,29 @@ jobs:
           overwrite: true
       # Upload results to SonarCloud
       - name: Upload results to SonarCloud
+        if: inputs.sonarcloud
         env:
           GHL_USERNAME: ${{ secrets.GHL_USERNAME }}
           GHL_PASSWORD: ${{ secrets.GHL_PASSWORD }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        run: ./gradlew sonar
+        run: ./gradlew --no-daemon sonar
       # Add code coverage to PR
-      - name: Add coverage report to PR
+      - name: Add code coverage to PR
         uses: mi-kas/kover-report@v1
         with:
+          title: Code Coverage ${{ inputs.gradle-module }}
           path: ${{ github.workspace }}/build/reports/kover/report.xml
           token: ${{ secrets.GITHUB_TOKEN }}
-          title: Code Coverage
+          min-coverage-overall: 70
+          min-coverage-changed-files: 70
           update-comment: true
-          min-coverage-overall: 60
-          min-coverage-changed-files: 60
           coverage-counter-type: LINE
+      # Publish test results
+      - name: Publish test results
+        uses: EnricoMi/publish-unit-test-result-action@v2
+        if: always()
+        with:
+          files: |
+            **/build/test-results/**/*.xml
+            **/build/test-results/**/*.trx
+            **/build/test-results/**/*.json

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -55,8 +55,8 @@ jobs:
     runs-on: ${{ inputs.action-runner }}
     timeout-minutes: 30
     env:
-      # set the gradle tasks based on the coverage tool
-      GRADLE_TASKS: ${{ inputs.coverage-tool == 'kover' && format('{0}:koverXmlReport {0}:koverHtmlReport', inputs.gradle-module) || format('{0}:test', inputs.gradle-module) }}
+      # set the gradle tasks based on the coverage tool and respecting any gradle-module used as input
+      GRADLE_TASKS: ${{ inputs.coverage-tool == 'kover' && format('{0}:ktlintCheck {0}:koverXmlReport {0}:koverHtmlReport', inputs.gradle-module) || format('{0}:ktlintCheck {0}:test', inputs.gradle-module) }}
     steps:
       # Checkout
       - name: Checkout
@@ -85,14 +85,8 @@ jobs:
         env:
           GHL_USERNAME: ${{ secrets.GHL_USERNAME }}
           GHL_PASSWORD: ${{ secrets.GHL_PASSWORD }}
-          GRADLE_MODULE: ${{ inputs.gradle-module }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          if [ -z "$GRADLE_MODULE" ]; then
-            ./gradlew --no-daemon ktlintCheck ${{ env.GRADLE_TASKS }} --parallel
-          else
-            ./gradlew --no-daemon $GRADLE_MODULE:ktlintCheck $GRADLE_MODULE:${{ env.GRADLE_TASKS }} --parallel
-          fi
+        run: ./gradlew --no-daemon ${{ env.GRADLE_TASKS }} --parallel
         shell: bash
       # Upload test results
       - name: Upload test results

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -1,4 +1,4 @@
-name: Build and test
+name: Build and test (Jacoco)
 on:
   workflow_call:
     inputs:
@@ -19,11 +19,6 @@ on:
         required: false
         type: string
         description: "Name of the gradle module being tested - only needed if you want to test one module in a multi-module project"
-      coverage-tool:
-        required: false
-        type: string
-        default: 'jacoco'
-        description: "Coverage tool [jacoco|kover]"
       sonarcloud:
         required: false
         type: boolean
@@ -54,9 +49,6 @@ jobs:
     name: Test with code coverage
     runs-on: ${{ inputs.action-runner }}
     timeout-minutes: 30
-    env:
-      # set the gradle tasks based on the coverage tool and respecting any gradle-module used as input
-      GRADLE_TASKS: ${{ inputs.coverage-tool == 'kover' && format('{0}:ktlintCheck {0}:koverXmlReport {0}:koverHtmlReport', inputs.gradle-module) || format('{0}:ktlintCheck {0}:test', inputs.gradle-module) }}
     steps:
       # Checkout
       - name: Checkout
@@ -81,12 +73,13 @@ jobs:
           key: ${{ runner.os }}-sonar
           restore-keys: ${{ runner.os }}-sonar
       # Run tests with coverage
-      - name: Run tests with coverage (${{ inputs.coverage-tool }})
+      - name: Run tests with coverage
         env:
           GHL_USERNAME: ${{ secrets.GHL_USERNAME }}
           GHL_PASSWORD: ${{ secrets.GHL_PASSWORD }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: ./gradlew --no-daemon ${{ env.GRADLE_TASKS }} --parallel
+        # set the gradle tasks respecting any gradle-module used as input
+        run: ./gradlew --no-daemon ${{ format('{0}:ktlintCheck {0}:test', inputs.gradle-module) }} --parallel
         shell: bash
       # Upload test results
       - name: Upload test results
@@ -95,7 +88,6 @@ jobs:
         with:
           name: test-result
           path: |
-            ${{ github.workspace }}/build/reports/kover
             **/reports/tests/test
             /home/runner/.gradle/daemon/**/daemon-*.out.log
           retention-days: 2
@@ -108,10 +100,8 @@ jobs:
           GHL_PASSWORD: ${{ secrets.GHL_PASSWORD }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         run: ./gradlew --no-daemon sonar
-      # Add code coverage to PR (jacoco)
-      - name: Add code coverage to PR (jacoco)
-        if: ${{ inputs.coverage-tool == 'jacoco' }}
-        id: jacoco
+      # Add code coverage to PR
+      - name: Add code coverage to PR
         uses: madrapps/jacoco-report@v1.6.1
         with:
           title: Code Coverage ${{ inputs.gradle-module }}
@@ -120,18 +110,6 @@ jobs:
           min-coverage-overall: 70
           min-coverage-changed-files: 70
           update-comment: true
-      # Add code coverage to PR (kover)
-      - name: Add code coverage to PR (kover)
-        if: ${{ inputs.coverage-tool == 'kover' }}
-        uses: mi-kas/kover-report@v1
-        with:
-          title: Code Coverage ${{ inputs.gradle-module }}
-          path: ${{ github.workspace }}/build/reports/kover/report.xml
-          token: ${{ secrets.GITHUB_TOKEN }}
-          min-coverage-overall: 70
-          min-coverage-changed-files: 70
-          update-comment: true
-          coverage-counter-type: LINE
       # Publish test results
       - name: Publish test results
         uses: EnricoMi/publish-unit-test-result-action@v2

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -51,7 +51,7 @@ jobs:
     timeout-minutes: 30
     env:
       # set the gradle tasks based on the coverage tool
-      GRADLE_TASKS: ${{ inputs.coverage-tool == 'kover' && 'koverXmlReport koverHtmlReport' || 'test' }}
+      GRADLE_TASKS: ${{ inputs.coverage-tool == 'kover' && '$inputs.gradle-module:koverXmlReport $inputs.gradle-module:koverHtmlReport' || '$inputs.gradle-module:test' }}
     steps:
       # Checkout
       - name: Checkout
@@ -75,20 +75,6 @@ jobs:
           path: ~/.sonar/cache
           key: ${{ runner.os }}-sonar
           restore-keys: ${{ runner.os }}-sonar
-      # Run linter
-      - name: Run linter
-        env:
-          GHL_USERNAME: ${{ secrets.GHL_USERNAME }}
-          GHL_PASSWORD: ${{ secrets.GHL_PASSWORD }}
-          GRADLE_MODULE: ${{ inputs.gradle-module }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          if [ -z "$GRADLE_MODULE" ]; then
-            ./gradlew --no-daemon ktlintCheck
-          else
-            ./gradlew --no-daemon $GRADLE_MODULE:ktlintCheck
-          fi
-        shell: bash
       # Run tests with coverage
       - name: Run tests with coverage ${{ inputs.coverage-tool }}
         env:
@@ -98,9 +84,9 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           if [ -z "$GRADLE_MODULE" ]; then
-            ./gradlew --no-daemon ${{ env.GRADLE_TASKS }} --parallel
+            ./gradlew --no-daemon ktlintCheck ${{ env.GRADLE_TASKS }} --parallel
           else
-            ./gradlew --no-daemon $GRADLE_MODULE:${{ env.GRADLE_TASKS }} --parallel
+            ./gradlew --no-daemon $GRADLE_MODULE:ktlintCheck $GRADLE_MODULE:${{ env.GRADLE_TASKS }} --parallel
           fi
         shell: bash
       # Upload test results
@@ -123,8 +109,8 @@ jobs:
           GHL_PASSWORD: ${{ secrets.GHL_PASSWORD }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         run: ./gradlew sonar
-      # Add code coverage to PR
-      - name: add code coverage to PR (jacoco)
+      # Add code coverage to PR (jacoco)
+      - name: Add code coverage to PR (jacoco)
         if: ${{ inputs.coverage-tool == 'jacoco' }}
         id: jacoco
         uses: madrapps/jacoco-report@v1.6.1
@@ -135,7 +121,7 @@ jobs:
           min-coverage-overall: 70
           min-coverage-changed-files: 70
           update-comment: true
-      # Add code coverage to PR
+      # Add code coverage to PR (kover)
       - name: Add code coverage to PR (kover)
         if: ${{ inputs.coverage-tool == 'kover' }}
         uses: mi-kas/kover-report@v1
@@ -147,7 +133,8 @@ jobs:
           min-coverage-changed-files: 70
           update-comment: true
           coverage-counter-type: LINE
-      - name: Publish Test Results
+      # Publish test results
+      - name: Publish test results
         uses: EnricoMi/publish-unit-test-result-action@v2
         if: always()
         with:

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -51,7 +51,7 @@ jobs:
     timeout-minutes: 30
     env:
       # set the gradle tasks based on the coverage tool
-      GRADLE_TASKS: ${{ coverage-tool == 'kover' && 'koverXmlReport koverHtmlReport' || 'test' }}
+      GRADLE_TASKS: ${{ inputs.coverage-tool == 'kover' && 'koverXmlReport koverHtmlReport' || 'test' }}
     steps:
       # Checkout
       - name: Checkout
@@ -69,7 +69,7 @@ jobs:
           cache: 'gradle'
       # Cache SonarCloud packages
       - name: Cache SonarCloud packages
-        if: ${{ SONAR_TOKEN }}
+        if: ${{ secrets.SONAR_TOKEN }}
         uses: actions/cache@v4
         with:
           path: ~/.sonar/cache
@@ -90,7 +90,7 @@ jobs:
           fi
         shell: bash
       # Run tests with coverage
-      - name: Run tests with coverage ${{ coverage-tool }}
+      - name: Run tests with coverage ${{ inputs.coverage-tool }}
         env:
           GHL_USERNAME: ${{ secrets.GHL_USERNAME }}
           GHL_PASSWORD: ${{ secrets.GHL_PASSWORD }}
@@ -117,7 +117,7 @@ jobs:
           overwrite: true
       # Upload results to SonarCloud
       - name: Upload results to SonarCloud
-        if: ${{ SONAR_TOKEN }}
+        if: ${{ secrets.SONAR_TOKEN }}
         env:
           GHL_USERNAME: ${{ secrets.GHL_USERNAME }}
           GHL_PASSWORD: ${{ secrets.GHL_PASSWORD }}
@@ -125,7 +125,7 @@ jobs:
         run: ./gradlew sonar
       # Add code coverage to PR
       - name: add code coverage to PR (jacoco)
-        if: ${{ coverage-tool == 'jacoco' }}
+        if: ${{ inputs.coverage-tool == 'jacoco' }}
         id: jacoco
         uses: madrapps/jacoco-report@v1.6.1
         with:
@@ -137,7 +137,7 @@ jobs:
           update-comment: true
       # Add code coverage to PR
       - name: Add code coverage to PR (kover)
-        if: ${{ coverage-tool == 'kover' }}
+        if: ${{ inputs.coverage-tool == 'kover' }}
         uses: mi-kas/kover-report@v1
         with:
           title: Code Coverage ${{ inputs.gradle-module }}

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -51,7 +51,7 @@ jobs:
     timeout-minutes: 30
     env:
       # set the gradle tasks based on the coverage tool
-      GRADLE_TASKS: ${{ coverage == 'kover' && 'koverXmlReport koverHtmlReport' || 'test' }}
+      GRADLE_TASKS: ${{ coverage-tool == 'kover' && 'koverXmlReport koverHtmlReport' || 'test' }}
     steps:
       # Checkout
       - name: Checkout
@@ -90,7 +90,7 @@ jobs:
           fi
         shell: bash
       # Run tests with coverage
-      - name: Run tests with coverage ${{ coverage }}
+      - name: Run tests with coverage ${{ coverage-tool }}
         env:
           GHL_USERNAME: ${{ secrets.GHL_USERNAME }}
           GHL_PASSWORD: ${{ secrets.GHL_PASSWORD }}
@@ -125,7 +125,7 @@ jobs:
         run: ./gradlew sonar
       # Add code coverage to PR
       - name: add code coverage to PR (jacoco)
-        if: ${{ coverage == 'jacoco' }}
+        if: ${{ coverage-tool == 'jacoco' }}
         id: jacoco
         uses: madrapps/jacoco-report@v1.6.1
         with:
@@ -137,7 +137,7 @@ jobs:
           update-comment: true
       # Add code coverage to PR
       - name: Add code coverage to PR (kover)
-        if: ${{ coverage == 'kover' }}
+        if: ${{ coverage-tool == 'kover' }}
         uses: mi-kas/kover-report@v1
         with:
           title: Code Coverage ${{ inputs.gradle-module }}

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -24,6 +24,11 @@ on:
         type: string
         default: 'jacoco'
         description: "Coverage tool [jacoco|kover]"
+      sonarcloud:
+        required: false
+        type: boolean
+        default: false
+        description: "Upload report to SonarCloud (SONAR_TOKEN must be set)"
     secrets:
       GHL_USERNAME:
         required: true
@@ -41,7 +46,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: Slashgear/action-check-pr-title@v4.3.0
+      - uses: Slashgear/action-check-pr-title@v4
         with:
           regexp: '^(\[(develop|development|staging)\]\s)?(build|chore|ci|docs|feat|feature|fix|perf|refactor|revert|style|test|release|ignore)(\([\w\- ]+\))?!?: (.+)'
           helpMessage: "Example: 'feat(app-api): Add new vehicle integration (SERVER-123)'"
@@ -51,7 +56,7 @@ jobs:
     timeout-minutes: 30
     env:
       # set the gradle tasks based on the coverage tool
-      GRADLE_TASKS: ${{ inputs.coverage-tool == 'kover' && '$inputs.gradle-module:koverXmlReport $inputs.gradle-module:koverHtmlReport' || '$inputs.gradle-module:test' }}
+      GRADLE_TASKS: ${{ inputs.coverage-tool == 'kover' && format('{0}:koverXmlReport {0}:koverHtmlReport', inputs.gradle-module) || format('{0}:test', inputs.gradle-module) }}
     steps:
       # Checkout
       - name: Checkout
@@ -69,14 +74,14 @@ jobs:
           cache: 'gradle'
       # Cache SonarCloud packages
       - name: Cache SonarCloud packages
-#        if: ${{ secrets.SONAR_TOKEN }}
+        if: inputs.sonarcloud
         uses: actions/cache@v4
         with:
           path: ~/.sonar/cache
           key: ${{ runner.os }}-sonar
           restore-keys: ${{ runner.os }}-sonar
       # Run tests with coverage
-      - name: Run tests with coverage ${{ inputs.coverage-tool }}
+      - name: Run tests with coverage (${{ inputs.coverage-tool }})
         env:
           GHL_USERNAME: ${{ secrets.GHL_USERNAME }}
           GHL_PASSWORD: ${{ secrets.GHL_PASSWORD }}
@@ -91,7 +96,7 @@ jobs:
         shell: bash
       # Upload test results
       - name: Upload test results
-        if: ${{ always() }}
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: test-result
@@ -103,12 +108,12 @@ jobs:
           overwrite: true
       # Upload results to SonarCloud
       - name: Upload results to SonarCloud
- #       if: ${{ secrets.SONAR_TOKEN }}
+        if: inputs.sonarcloud
         env:
           GHL_USERNAME: ${{ secrets.GHL_USERNAME }}
           GHL_PASSWORD: ${{ secrets.GHL_PASSWORD }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        run: ./gradlew sonar
+        run: ./gradlew --no-daemon sonar
       # Add code coverage to PR (jacoco)
       - name: Add code coverage to PR (jacoco)
         if: ${{ inputs.coverage-tool == 'jacoco' }}

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -69,7 +69,7 @@ jobs:
           cache: 'gradle'
       # Cache SonarCloud packages
       - name: Cache SonarCloud packages
-        if: ${{ secrets.SONAR_TOKEN }}
+#        if: ${{ secrets.SONAR_TOKEN }}
         uses: actions/cache@v4
         with:
           path: ~/.sonar/cache
@@ -98,9 +98,9 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           if [ -z "$GRADLE_MODULE" ]; then
-            ./gradlew --no-daemon ${{ GRADLE_TASKS }} --parallel
+            ./gradlew --no-daemon ${{ env.GRADLE_TASKS }} --parallel
           else
-            ./gradlew --no-daemon $GRADLE_MODULE:${{ GRADLE_TASKS }} --parallel
+            ./gradlew --no-daemon $GRADLE_MODULE:${{ env.GRADLE_TASKS }} --parallel
           fi
         shell: bash
       # Upload test results
@@ -117,7 +117,7 @@ jobs:
           overwrite: true
       # Upload results to SonarCloud
       - name: Upload results to SonarCloud
-        if: ${{ secrets.SONAR_TOKEN }}
+ #       if: ${{ secrets.SONAR_TOKEN }}
         env:
           GHL_USERNAME: ${{ secrets.GHL_USERNAME }}
           GHL_PASSWORD: ${{ secrets.GHL_PASSWORD }}

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -2,6 +2,11 @@ name: Build and test
 on:
   workflow_call:
     inputs:
+      action-runner:
+        required: false
+        type: string
+        description: "Runner to use for the job"
+        default: 'ubuntu-latest'
       java-distribution:
         required: false
         type: string
@@ -13,7 +18,12 @@ on:
       gradle-module:
         required: false
         type: string
-        description: "Name of the gradle module being tested"
+        description: "Name of the gradle module being tested - only needed if you want to test one module in a multi-module project"
+      coverage-tool:
+        required: false
+        type: string
+        default: 'jacoco'
+        description: "Coverage tool [jacoco|kover]"
     secrets:
       GHL_USERNAME:
         required: true
@@ -21,12 +31,12 @@ on:
       GHL_PASSWORD:
         required: true
         description: "Github Password (Gradle plugin)"
-      SLACK_APP_TOKEN:
+      SONAR_TOKEN:
         required: false
-        description: "Slack app token (Optional, won't publish to slack if not present)"
+        description: "SonarCloud token"
 jobs:
   pr_title_checker:
-    name: PR title checker
+    name: Check PR title
     if: ${{ github.event_name == 'pull_request' }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -36,20 +46,36 @@ jobs:
           regexp: '^(\[(develop|development|staging)\]\s)?(build|chore|ci|docs|feat|feature|fix|perf|refactor|revert|style|test|release|ignore)(\([\w\- ]+\))?!?: (.+)'
           helpMessage: "Example: 'feat(app-api): Add new vehicle integration (SERVER-123)'"
   test:
-    name: Test
-    runs-on: ubuntu-latest
+    name: Test with code coverage
+    runs-on: ${{ inputs.action-runner }}
     timeout-minutes: 30
+    env:
+      # set the gradle tasks based on the coverage tool
+      GRADLE_TASKS: ${{ coverage == 'kover' && 'koverXmlReport koverHtmlReport' || 'test' }}
     steps:
+      # Checkout
       - name: Checkout
         uses: actions/checkout@v4
         with:
+          # to check out the actual pull request commit, not the merge commit
           ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+      # Set up JDK
       - name: Set up JDK
         uses: actions/setup-java@v4
         with:
           distribution: ${{ inputs.java-distribution }}
           java-version: ${{ inputs.java-version }}
           cache: 'gradle'
+      # Cache SonarCloud packages
+      - name: Cache SonarCloud packages
+        if: ${{ SONAR_TOKEN }}
+        uses: actions/cache@v4
+        with:
+          path: ~/.sonar/cache
+          key: ${{ runner.os }}-sonar
+          restore-keys: ${{ runner.os }}-sonar
+      # Run linter
       - name: Run linter
         env:
           GHL_USERNAME: ${{ secrets.GHL_USERNAME }}
@@ -63,7 +89,8 @@ jobs:
             ./gradlew --no-daemon $GRADLE_MODULE:ktlintCheck
           fi
         shell: bash
-      - name: Test project
+      # Run tests with coverage
+      - name: Run tests with coverage ${{ coverage }}
         env:
           GHL_USERNAME: ${{ secrets.GHL_USERNAME }}
           GHL_PASSWORD: ${{ secrets.GHL_PASSWORD }}
@@ -71,31 +98,55 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           if [ -z "$GRADLE_MODULE" ]; then
-            ./gradlew --no-daemon test
+            ./gradlew --no-daemon ${{ GRADLE_TASKS }} --parallel
           else
-            ./gradlew --no-daemon $GRADLE_MODULE:test
+            ./gradlew --no-daemon $GRADLE_MODULE:${{ GRADLE_TASKS }} --parallel
           fi
         shell: bash
+      # Upload test results
       - name: Upload test results
         if: ${{ always() }}
         uses: actions/upload-artifact@v4
         with:
           name: test-result
           path: |
+            ${{ github.workspace }}/build/reports/kover
             **/reports/tests/test
             /home/runner/.gradle/daemon/**/daemon-*.out.log
           retention-days: 2
           overwrite: true
-      - name: add coverage to PR
+      # Upload results to SonarCloud
+      - name: Upload results to SonarCloud
+        if: ${{ SONAR_TOKEN }}
+        env:
+          GHL_USERNAME: ${{ secrets.GHL_USERNAME }}
+          GHL_PASSWORD: ${{ secrets.GHL_PASSWORD }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        run: ./gradlew sonar
+      # Add code coverage to PR
+      - name: add code coverage to PR (jacoco)
+        if: ${{ coverage == 'jacoco' }}
         id: jacoco
         uses: madrapps/jacoco-report@v1.6.1
         with:
+          title: Code Coverage ${{ inputs.gradle-module }}
           paths: ${{ github.workspace }}/**/jacocoTestReport.xml
           token: ${{ secrets.GITHUB_TOKEN }}
           min-coverage-overall: 70
           min-coverage-changed-files: 70
-          title: Code Coverage ${{ inputs.gradle-module }}
           update-comment: true
+      # Add code coverage to PR
+      - name: Add code coverage to PR (kover)
+        if: ${{ coverage == 'kover' }}
+        uses: mi-kas/kover-report@v1
+        with:
+          title: Code Coverage ${{ inputs.gradle-module }}
+          path: ${{ github.workspace }}/build/reports/kover/report.xml
+          token: ${{ secrets.GITHUB_TOKEN }}
+          min-coverage-overall: 70
+          min-coverage-changed-files: 70
+          update-comment: true
+          coverage-counter-type: LINE
       - name: Publish Test Results
         uses: EnricoMi/publish-unit-test-result-action@v2
         if: always()


### PR DESCRIPTION
* workflow code also have rights to be simplified and not be duplicated :-) 
* this merges the pull-request.yaml and pull-request-kover.yaml into one parameterized file - I saw how they duplicated a lot of stuff and in different ways :-/
* this PR over in OCPP shows how to parameterize it https://github.com/monta-app/service-ocpp/pull/1593 - just set the coverage tool (defaults to jacoco) like this
```yaml
      coverage-tool: kover
      sonarcloud: true
```
* this updated version also supports the 'gradle-module' argument correctly again to build individual modules in multi-module projects.