### PR TITLE
fail deploy-ocpp-gateway step on non-200 from infra portal

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -785,4 +785,10 @@ jobs:
       - name: send POST to Infra Portal
         # this still has some static values just to get the ball rolling, will be changed later
         run: |
-          curl -X POST -H "Authorization: Bearer ${{ secrets.INFRA_PORTAL_TOKEN }}" -H "Content-Type: application/json" -d '{"commitHash": "'"${GITHUB_SHA}"'", "buildNumber": "'"${{ github.run_number }}"'", "awsAccountId": "'"${{ secrets.AWS_ACCOUNT_ID }}"'", "replicas": ${{ inputs.ocpp-gateway-replicas }}}' https://${{ needs.init.outputs.infra-portal-server }}/ocpp-${{ inputs.stage }}/${{ inputs.service-identifier }}-${{ inputs.stage }}/create-gateway-release
+          response_code=$(curl --write-out '%{http_code}' --silent -o resp_body.txt -X POST -H "Authorization: Bearer ${{ secrets.INFRA_PORTAL_TOKEN }}" -H "Content-Type: application/json" -d '{"commitHash": "'"${GITHUB_SHA}"'", "buildNumber": "'"${{ github.run_number }}"'", "awsAccountId": "'"${{ secrets.AWS_ACCOUNT_ID }}"'", "replicas": ${{ inputs.ocpp-gateway-replicas }}}' https://${{ needs.init.outputs.infra-portal-server }}/ocpp-${{ inputs.stage }}/${{ inputs.service-identifier }}-${{ inputs.stage }}/create-gateway-release)
+          if [[ $response_code != "200" ]]; then
+            echo "::error::$(cat resp_body.txt)"
+            exit 1
+          else
+            cat resp_body.txt
+          fi


### PR DESCRIPTION
writes the response code to the `response_code` var and the body to `resp_body.txt`, and fails if non 200, because develops saw that the workflow completed without error even though there was an error in the POST to the infra-portal