### PR TITLE
feat: make running tests in parallel optional

### DIFF
--- a/.github/workflows/pull-request-kover.yaml
+++ b/.github/workflows/pull-request-kover.yaml
@@ -19,6 +19,11 @@ on:
         required: false
         type: string
         description: "Name of the gradle module being tested - only needed if you want to test one module in a multi-module project"
+      gradle-parallel:
+        required: false
+        type: boolean
+        default: true
+        description: "Run gradle tasks in parallel"
       sonarcloud:
         required: false
         type: boolean
@@ -79,7 +84,7 @@ jobs:
           GHL_PASSWORD: ${{ secrets.GHL_PASSWORD }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         # set the gradle tasks respecting any gradle-module used as input
-        run: ./gradlew --no-daemon ${{ format('{0}:ktlintCheck {0}:koverXmlReport {0}:koverHtmlReport', inputs.gradle-module) }} --parallel
+        run: ./gradlew --no-daemon ${{ format('{0}:ktlintCheck {0}:koverXmlReport {0}:koverHtmlReport', inputs.gradle-module) }} ${{ inputs.gradle-parallel && '--parallel' || ''}}
         shell: bash
       # Upload test results
       - name: Upload test results

--- a/.github/workflows/pull-request-kover.yaml
+++ b/.github/workflows/pull-request-kover.yaml
@@ -19,11 +19,11 @@ on:
         required: false
         type: string
         description: "Name of the gradle module being tested - only needed if you want to test one module in a multi-module project"
-      gradle-parallel:
+      gradle-parallel-tests:
         required: false
         type: boolean
         default: true
-        description: "Run gradle tasks in parallel"
+        description: "Run gradle tests in parallel"
       sonarcloud:
         required: false
         type: boolean
@@ -84,7 +84,7 @@ jobs:
           GHL_PASSWORD: ${{ secrets.GHL_PASSWORD }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         # set the gradle tasks respecting any gradle-module used as input
-        run: ./gradlew --no-daemon ${{ format('{0}:ktlintCheck {0}:koverXmlReport {0}:koverHtmlReport', inputs.gradle-module) }} ${{ inputs.gradle-parallel && '--parallel' || ''}}
+        run: ./gradlew --no-daemon ${{ format('{0}:ktlintCheck {0}:koverXmlReport {0}:koverHtmlReport', inputs.gradle-module) }} ${{ inputs.gradle-parallel-tests && '--parallel' || ''}}
         shell: bash
       # Upload test results
       - name: Upload test results

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -19,6 +19,11 @@ on:
         required: false
         type: string
         description: "Name of the gradle module being tested - only needed if you want to test one module in a multi-module project"
+      gradle-parallel-tests:
+        required: false
+        type: boolean
+        default: true
+        description: "Run gradle tests in parallel"
       sonarcloud:
         required: false
         type: boolean
@@ -79,7 +84,7 @@ jobs:
           GHL_PASSWORD: ${{ secrets.GHL_PASSWORD }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         # set the gradle tasks respecting any gradle-module used as input
-        run: ./gradlew --no-daemon ${{ format('{0}:ktlintCheck {0}:test', inputs.gradle-module) }} --parallel
+        run: ./gradlew --no-daemon ${{ format('{0}:ktlintCheck {0}:test', inputs.gradle-module) }} ${{ inputs.gradle-parallel-tests && '--parallel' || ''}}
         shell: bash
       # Upload test results
       - name: Upload test results


### PR DESCRIPTION
Make gradle `--parallel` parameter optional so that tests can be run sequentially if needed. It is enabled by default, so if left out, tests are run in parallel. That makes this change backwards-compatible to previous behavior where it was always enabled.