### PR TITLE
feat: incroduces workflows for auto-creating release PRs (PS-442)

### DIFF
--- a/.github/workflows/monta-merge-command.yaml
+++ b/.github/workflows/monta-merge-command.yaml
@@ -1,0 +1,51 @@
+name: Pull Request Commands to auto-merge PRs to staging or production branch
+
+on:
+  workflow_call:
+    outputs:
+      base_branch:
+        description: "The base branch that the workflow merged to. Used to determine subsequent deployment actions."
+        value: ${{ jobs.monta-merge.outputs.base_branch }}
+
+jobs:
+  monta-merge:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.issue.pull_request && startsWith(github.event.comment.body, '/monta-merge') }}
+    outputs:
+      base_branch: ${{ steps.get-branch.outputs.base_branch }}
+    steps:
+    - name: Get branch names of PR
+      id: get-branch
+      env:
+        REPO: ${{ github.repository }}
+        PR_NO: ${{ github.event.issue.number }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        export PR_DATA=$(gh pr view $PR_NO --repo $REPO --json headRefName,baseRefName,mergeable)
+        echo head_branch=$(jq -nr "$PR_DATA | .headRefName") >> "$GITHUB_OUTPUT"
+        echo base_branch=$(jq -nr "$PR_DATA | .baseRefName") >> "$GITHUB_OUTPUT"
+        echo mergeable=$(jq -nr "$PR_DATA | .mergeable") >> "$GITHUB_OUTPUT"
+
+    - name: Check out base branch
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+        ref: ${{ steps.get-branch.outputs.base_branch }}
+
+    - name: Merge changes
+      # Only develop -> staging or staging -> production
+      if: | 
+        ${{ steps.get-branch.outputs.mergeable == 'MERGEABLE' && 
+          (
+            (steps.get-branch.outputs.head_branch == 'develop' 
+              && steps.get-branch.outputs.base_branch == 'staging') || 
+            (steps.get-branch.outputs.head_branch == 'staging' 
+              && steps.get-branch.outputs.base_branch == 'production')
+          ) 
+        }}
+      env:
+        HEAD_BRANCH: ${{ steps.get-branch.outputs.head_branch }}
+        BASE_BRANCH: ${{ steps.get-branch.outputs.base_branch }}
+      run: |
+        git merge --ff-only origin/$HEAD_BRANCH
+        git push origin $BASE_BRANCH

--- a/.github/workflows/production-pr.yaml
+++ b/.github/workflows/production-pr.yaml
@@ -1,0 +1,29 @@
+name: Auto-create PR to promote staging to main
+
+on:
+  workflow_call:
+
+env:
+  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  REPO: ${{github.repository}}
+
+jobs:
+  auto_create_pr:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Auto create production PR if it does not exist
+        run: |
+          OPEN_PR=$(gh pr view staging --repo $REPO --jq 'select(.state == "OPEN" and .baseRefName == "main")' --json number,state,baseRefName || echo "")
+
+          if [ -z "$OPEN_PR" ]; then
+            TITLE='release: production'
+            BODY='Update main with latest changes from staging. Approve this PR and merge it by commenting `/monta-merge`.'
+            gh pr create \
+              --repo $REPO \
+              --base main \
+              --head staging \
+              --title "$TITLE" \
+              --body "$BODY"
+          else
+            echo "PR already exists"
+          fi

--- a/.github/workflows/release-tag.yaml
+++ b/.github/workflows/release-tag.yaml
@@ -1,0 +1,41 @@
+name: Auto-create the release tag
+
+on:
+  workflow_call:
+    outputs:
+      tag_exists:
+        description: "Indicates whether a tag already exists for the latest commit."
+        value: ${{ jobs.create-tag.outputs.tag_exists }}
+
+jobs:
+  create-tag:
+    runs-on: ubuntu-latest
+
+    outputs:
+      tag_exists: ${{ steps.check-tag.outputs.tag_exists }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check if the latest commit is already tagged
+        id: check-tag
+        run: |
+          git fetch --tags
+          if git describe --exact-match --tags $(git rev-parse HEAD); then
+            echo "tag_exists=true" >> $GITHUB_OUTPUT
+          else
+            echo "tag_exists=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Create the release tag
+        if: steps.check-tag.outputs.tag_exists == 'false'
+        run: |
+          TAG_NAME=$(date -u +%Y-%m-%d-%H-%M)
+          TAG_MESSAGE="Release $(date -u +'%Y-%m-%d %H:%M UTC')"
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+          git tag -a "$TAG_NAME" -m "$TAG_MESSAGE"
+          git push origin "$TAG_NAME"

--- a/.github/workflows/staging-pr.yaml
+++ b/.github/workflows/staging-pr.yaml
@@ -1,0 +1,29 @@
+name: Auto-create PR to promote develop to staging
+
+on:
+  workflow_call:
+
+env:
+  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  REPO: ${{github.repository}}
+
+jobs:
+  auto_create_pr:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Auto create staging PR if it does not exist
+        run: |
+          OPEN_PR=$(gh pr view develop --repo $REPO --jq 'select(.state == "OPEN" and .baseRefName == "staging")' --json number,state,baseRefName || echo "")
+
+          if [ -z "$OPEN_PR" ]; then
+            TITLE='release: staging'
+            BODY='Update staging with latest changes from develop. Approve this PR and merge it by commenting `/monta-merge`.'
+            gh pr create \
+              --repo $REPO \
+              --base staging \
+              --head develop \
+              --title "$TITLE" \
+              --body "$BODY"
+          else
+            echo "PR already exists"
+          fi

--- a/README.md
+++ b/README.md
@@ -1,0 +1,108 @@
+# GitHub Workflows
+
+This repository contains several reusable workflows designed to streamline the CI/CD process. The workflows aim to automate tasks such as testing, deployment, pull request management, and code quality checks.
+
+## Available Workflows
+
+### `backstage_techdocs.yaml`
+- **Purpose**: Manages the deployment of technical documentation using Backstage TechDocs.
+
+### `it-test.yaml`
+- **Purpose**: Runs integration tests for ensuring code stability.
+
+### `pull-request.yaml`
+- **Purpose**: Automates actions based on pull request events such as title validation, code coverage reports, and testing.
+
+### `sonar-cloud.yaml`
+- **Purpose**: Integrates with SonarCloud for analyzing code quality and vulnerabilities.
+
+### `deploy.yaml`
+- **Purpose**: Manages deployments to various environments based on the branch being deployed.
+
+### `pull-request-kover.yaml`
+- **Purpose**: Manages the execution of Kover, a Kotlin coverage engine, for code coverage on pull requests.
+
+### `monta-merge-command.yaml`
+- **Purpose**: Automates the process of merging pull requests and triggering subsequent deployment steps for `staging` and `production`.
+
+### `release-tag.yaml`
+- **Purpose**: Automatically tags releases with a timestamped version.
+
+### `staging-pr.yaml`
+- **Purpose**: Automatically creates a pull request to promote changes from `develop` to `staging`.
+
+### `production-pr.yaml`
+- **Purpose**: Automatically creates a pull request for promoting changes to the `production` branch.
+---
+
+## How to Use
+
+### 1. **Auto-create PR to Promote `develop` to `staging`**
+
+This workflow is triggered by pushes to the `develop` branch. It automatically creates a pull request to promote changes to the `staging` branch using the `staging-pr.yaml` workflow.
+
+**Example**:
+```yaml
+name: Auto-create PR to promote develop to staging
+
+on:
+  push:
+    branches:
+      - develop
+
+jobs:
+  staging_pr:
+    name: Pull request (Staging)
+    uses: monta-app/github-workflows/.github/workflows/staging-pr.yaml@v2
+```
+
+### 2. **Use workflows for release PR merging, production tagging and deployment**
+
+This workflow listens for comments on pull requests and responds to specific commands.
+It handles automatic PR merging, staging deployment, production pull request creation, tagging, and deployment based on the command `/monta-merge`.
+
+**Example**:
+```yaml
+name: Release Workflow Automation
+on:
+  issue_comment:
+    types:
+      - created
+
+jobs:
+  monta-merge:
+    name: auto-merge release pull request
+    if: ${{ github.event.issue.pull_request && startsWith(github.event.comment.body, '/monta-merge') }}
+    uses: monta-app/github-workflows/.github/workflows/monta-merge-command.yaml@v2
+    secrets: inherit
+
+  trigger-staging-deploy:
+    needs: monta-merge
+    if: ${{ needs.monta-merge.outputs.base_branch == 'staging' }}
+    # change this to your deploy workflow
+    uses: ./.github/workflows/deploy_staging.yaml 
+    secrets: inherit
+
+  trigger-production-pr-creation:
+    needs: monta-merge
+    if: ${{ needs.monta-merge.outputs.base_branch == 'staging' }}
+    uses: monta-app/github-workflows/.github/workflows/production-pr.yaml@v2
+    secrets: inherit
+
+  trigger-production-tag-release:
+    needs: monta-merge
+    if: ${{ needs.monta-merge.outputs.base_branch == 'main' }}
+    uses: monta-app/github-workflows/.github/workflows/release-tag.yaml@v2
+    secrets: inherit
+
+  trigger-production-deploy:
+    needs: trigger-production-tag-release
+    # change this to your deploy workflow
+    uses: ./.github/workflows/deploy_production.yaml
+    if: ${{ needs.trigger-production-tag-release.outputs.tag_exists == 'false' }}
+    secrets: inherit
+```
+
+## Contributing ##
+
+If you are adding new workflows or updating existing ones, please ensure to update this `README` with descriptions and usage examples for easy integration by other teams. Make sure your workflows follow best practices for GitHub Actions to ensure reliability and maintainability.


### PR DESCRIPTION
This PR introduces workflows to automate the creation of release pull requests for staging and production environments. Additionally, it includes a `monta-merge` command that automatic merge pull requests and triggers deployments for both staging and main branches.

This setup streamlines the release process and ensures that changes are efficiently promoted through the deployment pipeline, reducing manual effort.

The New Workflows:

-  `staging-pr` & `production-pr`: These workflows automate the creation of pull requests for promoting changes from develop to staging and from staging to main.
-   `monta-merge-commands`: This workflow handles the execution of the monta-merge command, automating the merging process for pull requests. It ensures that changes from develop are merged into staging, and from staging into production, based on the head branch.
 -  `release-tag`: This workflow automatically creates a release tag for the latest commit if a tag does not already exist. It helps in marking the release points.


Examples:
- See the usage for the new workflows in the [pull_request_commands.yml](https://github.com/monta-app/service-audit-log-bridge/blob/develop/.github/workflows/pull_request_commands.yml) file.
 -  An example of a pull request created by these workflows can be viewed [here](https://github.com/monta-app/service-audit-log-bridge/pull/76).

