### PR TITLE
feat: remove if condition from monta-merge-command (PS-442)

### DIFF
--- a/.github/workflows/monta-merge-command.yaml
+++ b/.github/workflows/monta-merge-command.yaml
@@ -10,7 +10,6 @@ on:
 jobs:
   monta-merge:
     runs-on: ubuntu-latest
-    if: ${{ github.event.issue.pull_request && startsWith(github.event.comment.body, '/monta-merge') }}
     outputs:
       base_branch: ${{ steps.get-branch.outputs.base_branch }}
     steps:


### PR DESCRIPTION
This commits removes the if condition from monta merge command workflow to make the triggering of the monta-merge action configurable, we can rely on the if in the project workflow that calls it, as shown in the READEME.
