### PR TITLE
feat(deploy): Restrict production deployments to main/master (PS-487)

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -494,6 +494,21 @@ jobs:
           slack-message-id: ${{ needs.init.outputs.slack-message-id }}
       - name: Checkout
         uses: actions/checkout@v4
+      - name: Ensure commit belongs to release branch
+        if: ${{ inputs.stage == 'production' }}
+        run: |
+          # Fetch release branch candidates (! to allow non-existence)
+          ! git fetch origin master
+          ! git fetch origin main
+
+          # Check which branches contain the current HEAD (! to allow no grep matches)
+          ! IS_MAIN=$(git branch -r --contains HEAD --format '%(refname)' | grep -E '^refs/remotes/origin/(master|main)$')
+
+          # Fail if no matches
+          if [ -z "$IS_MAIN" ]; then
+            echo "Deployed ref is not part of release branch. Use main/master for production deploys."
+            exit 1
+          fi
       - name: Set up JDK
         uses: actions/setup-java@v4
         with:


### PR DESCRIPTION
Many of our projects trigger production deploys when any tag is pushed. There is no check whatsoever if the tagged commit is actually part of the main branch.

This is a small safeguard against accidentally pushing a tag on another branch than the production release branch.

Somewhat tested here:

Check fails
https://github.com/monta-app/service-internal-auth/actions/runs/11069685675/job/30757756483

Check succeeds
https://github.com/monta-app/service-internal-auth/actions/runs/11069708249/job/30757824576
