### PR TITLE
chore(it-test): use the main branch for the php server

### DIFF
--- a/.github/workflows/it-test.yaml
+++ b/.github/workflows/it-test.yaml
@@ -30,7 +30,7 @@ on:
       php-branch:
         required: false
         type: string
-        default: "staging"
+        default: "main"
         description: 'gradle module to be built'
       java-distribution:
         required: false


### PR DESCRIPTION
Php has dropped the staging branch support, this PR changes the workflow to rely on the main branch instead.