### PR TITLE
fix(deploy): make openapi backstage upload work when yml exists in gradle subproject

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -388,10 +388,10 @@ jobs:
               exit 1
           fi
           # Print the yml file
-          echo "Building catalog file from:${YML_FILE}"
+          echo "Building catalog file from: ${YML_FILE}"
           spec_file=${YML_FILE}
           service_name=${{ inputs.service-identifier }}
-          output_file_path="$OPENAPI_OUTPUT_DIR/catalog_${service_name}_api.yaml"
+          output_file_path="catalog_${service_name}_api.yaml"
 
           spec=$(cat $spec_file)
           # Build the final spec file
@@ -409,7 +409,7 @@ jobs:
             definition: |
           $(cat $spec_file | sed 's/^/    /')
           EndOfMessage
-          echo "Uploading catalog file from:${output_file_path}"
+          echo "Uploading catalog file from: ${output_file_path}"
           aws s3 cp ${output_file_path} s3://monta-tech-docs/api/
           echo "Upload complete."
       - name: Create service profile


### PR DESCRIPTION
There is an assumption that `OPENAPI_OUTPUT_DIR` is a prefix of `YML_FILE`. That is not the case if `YML_FILE` was found in a gradle subproject.

Example can be found [here](https://github.com/monta-app/service-grid/actions/runs/11275895966/job/31358811068#step:11:51).

Here, `YML_FILE` is `./grid/build/tmp/kapt3/classes/main/META-INF/swagger/grid.yml`, while `OPENAPI_OUTPUT_DIR` is `build/tmp/kapt3/classes/main/META-INF/swagger`.

If the assumption holds (which it does if there is only one gradle project and therefore a `/build` directory in the current working directory), things work, as the catalog file is then written to `build/tmp/kapt3/classes/main/META-INF/swagger/catalog_servicename_api.yaml` which is fine as the directory `build/tmp/kapt3/classes/main/META-INF/swagger/` already exists.

If the assumption does not hold, the directory `build/tmp/kapt3/classes/main/META-INF/swagger/` does NOT exist, because the `build` directory was created in a subdirectory. Creating the catalog file  `build/tmp/kapt3/classes/main/META-INF/swagger/catalog_servicename_api.yaml` then silently fails, as the directory of that file doesn't exist and it is not created automatically when cat'ing to a new file.

The solution is to create the catalog-file in the current working directory and upload it from there.
