### PR TITLE
Fix(it-test): Run migrations and seed database before it-tests

### DIFF
--- a/.github/workflows/it-test.yaml
+++ b/.github/workflows/it-test.yaml
@@ -59,6 +59,10 @@ jobs:
           mode: "services"
           profiles: "app,identity"
           aws-account-id: ${{ secrets.STAGING_AWS_ACCOUNT_ID }}
+      - name: Run PHP migrations
+        run: |
+          docker compose exec -T app php artisan migrate:fresh --seed
+        shell: bash
 
       #######################################################
       #######################################################

--- a/.github/workflows/it-test.yaml
+++ b/.github/workflows/it-test.yaml
@@ -61,7 +61,7 @@ jobs:
           aws-account-id: ${{ secrets.STAGING_AWS_ACCOUNT_ID }}
       - name: Run PHP migrations
         run: |
-          docker compose exec -T app php artisan migrate:fresh --seed
+          docker compose exec -T app php artisan migrate --seed
         shell: bash
 
       #######################################################


### PR DESCRIPTION
Not entirely sure what changed the last weeks but our it-tests started to fail, after some investigation I noticed that the DB migrations and the seeding of the database was not happening automatically anymore.

Fix:
I've added an extra step to execute the migrations and seeding before starting the tests.