### PR TITLE
feat: Run tests parameter

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -310,7 +310,7 @@ jobs:
           slack-message-id: ${{ needs.init.outputs.slack-message-id }}
 
   update-open-api-spec:
-    if: ${{ inputs.upload-open-api }}
+    if: ${{ always() && inputs.upload-open-api && needs.build.result == 'success' && needs.init.result == 'success' && (!inputs.run-tests || (inputs.run-tests && needs.test.result == 'success')) }}
     name: Update OpenAPI Spec
     needs: [ init, test, build ]
     runs-on: ubuntu-latest
@@ -608,7 +608,7 @@ jobs:
   push-manifest-list:
     name: Push Manifest
     needs: [ init, build, test ]
-    if: success()
+    if: ${{ always() && needs.build.result == 'success' && needs.init.result == 'success' && (!inputs.run-tests || (inputs.run-tests && needs.test.result == 'success')) }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -692,7 +692,7 @@ jobs:
           slack-message-id: ${{ needs.init.outputs.slack-message-id }}
 
   deploy_by_push:
-    if: ${{ inputs.push-to-manifests }}
+    if: ${{ always() && inputs.push-to-manifests && needs.push-manifest-list.result == 'success' && needs.init.result == 'success' }}
     name: Deploy (push)
     needs:
     - push-manifest-list
@@ -747,7 +747,7 @@ jobs:
           slack-message-id: ${{ needs.init.outputs.slack-message-id }}
 
   deploy_by_argocd:
-    if: ${{ ! inputs.push-to-manifests }}
+    if: ${{ always() && ! inputs.push-to-manifests && needs.push-manifest-list.result == 'success' && needs.init.result == 'success' }}
     name: Deploy (ArgoCD)
     needs:
     - push-manifest-list
@@ -796,7 +796,7 @@ jobs:
           slack-message-id: ${{ needs.init.outputs.slack-message-id }}
 
   deploy_ocpp_gateway:
-    if: ${{ inputs.service-identifier == 'ocpp-gateway' || inputs.service-identifier == 'ocpp-v201-gateway' }}
+    if: ${{ always() && inputs.service-identifier == 'ocpp-gateway' || inputs.service-identifier == 'ocpp-v201-gateway' && needs.push-manifest-list.result == 'success' && needs.init.result == 'success' }}
     name: Deploy OCPP Gateway
     needs:
     - init

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -78,6 +78,10 @@ on:
         required: false
         type: number
         default: 10
+      run-tests:
+        required: false
+        type: boolean
+        default: true
     secrets:
       GHL_USERNAME:
         required: true
@@ -251,6 +255,7 @@ jobs:
     needs: init
     runs-on: ${{ matrix.runner-type }}
     timeout-minutes: 30
+    if: ${{ inputs.run-tests }}
     strategy:
       matrix:
         runner-type: ${{ fromJSON(needs.init.outputs.runners) }}

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -796,7 +796,7 @@ jobs:
           slack-message-id: ${{ needs.init.outputs.slack-message-id }}
 
   deploy_ocpp_gateway:
-    if: ${{ always() && inputs.service-identifier == 'ocpp-gateway' || inputs.service-identifier == 'ocpp-v201-gateway' && needs.push-manifest-list.result == 'success' && needs.init.result == 'success' }}
+    if: ${{ ! failure() && ( inputs.service-identifier == 'ocpp-gateway' || inputs.service-identifier == 'ocpp-v201-gateway' ) }}
     name: Deploy OCPP Gateway
     needs:
     - init

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -310,7 +310,7 @@ jobs:
           slack-message-id: ${{ needs.init.outputs.slack-message-id }}
 
   update-open-api-spec:
-    if: ${{ always() && inputs.upload-open-api && needs.build.result == 'success' && needs.init.result == 'success' && (!inputs.run-tests || (inputs.run-tests && needs.test.result == 'success')) }}
+    if: ${{ ! failure() && inputs.upload-open-api }}
     name: Update OpenAPI Spec
     needs: [ init, test, build ]
     runs-on: ubuntu-latest
@@ -608,7 +608,7 @@ jobs:
   push-manifest-list:
     name: Push Manifest
     needs: [ init, build, test ]
-    if: ${{ always() && needs.build.result == 'success' && needs.init.result == 'success' && (!inputs.run-tests || (inputs.run-tests && needs.test.result == 'success')) }}
+    if: ${{ ! failure() }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -692,7 +692,7 @@ jobs:
           slack-message-id: ${{ needs.init.outputs.slack-message-id }}
 
   deploy_by_push:
-    if: ${{ always() && inputs.push-to-manifests && needs.push-manifest-list.result == 'success' && needs.init.result == 'success' }}
+    if: ${{ ! failure() && inputs.push-to-manifests }}
     name: Deploy (push)
     needs:
     - push-manifest-list
@@ -747,7 +747,7 @@ jobs:
           slack-message-id: ${{ needs.init.outputs.slack-message-id }}
 
   deploy_by_argocd:
-    if: ${{ always() && ! inputs.push-to-manifests && needs.push-manifest-list.result == 'success' && needs.init.result == 'success' }}
+    if: ${{ ! failure() && ! inputs.push-to-manifests }}
     name: Deploy (ArgoCD)
     needs:
     - push-manifest-list


### PR DESCRIPTION
With continuous deploy, we don't run tests during deploy, because they have been run before merge of the PR into the trunk branch.

We need to parameterize whether to run tests or not in the deploy job from the outside to be able to use it for continuous deployment.

This PR introduces a parameter that allows for that control and keeps the default behavior for consumers that don't set the parameter.

When using `needs`, a default `if: success()` is added to the job, requiring dependencies to succeed. This can be circumvented using either `if: ! failure()` or more specifically `if: always() && needs.build.result == 'success' && needs.init.result == 'success' && (!inputs.run-tests || (inputs.run-tests && needs.test.result == 'success'))`.
I've chosen `!failure()` here to keep the complexity down.

I've tested locally with act, so I'm pretty confident that it works, however, it does open the door to continue on skipped init and build jobs (like we do for the test job). We don't skip init or build today, but might in the future, which might then act surprisingly.
I couldn't find a good way to test these things in CI, which would have been the most comfortable, so I think this is the best we can do for now.

Context: https://montaapp.atlassian.net/browse/SRE-701