### PR TITLE
feat: pull-request workflow - change logic so we run "test" and not ":test" if g…

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -84,7 +84,7 @@ jobs:
           GHL_PASSWORD: ${{ secrets.GHL_PASSWORD }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         # set the gradle tasks respecting any gradle-module used as input
-        run: ./gradlew --no-daemon ${{ format('{0}:ktlintCheck {0}:test', inputs.gradle-module) }} ${{ inputs.gradle-parallel-tests && '--parallel' || ''}}
+        run: ./gradlew --no-daemon ${{ inputs.gradle-module && format('{0}:ktlintCheck {0}:test', inputs.gradle-module) || 'ktlintCheck test' }} ${{ inputs.gradle-parallel-tests && '--parallel' || ''}}
         shell: bash
       # Upload test results
       - name: Upload test results


### PR DESCRIPTION
…radle-module not specified as arg

We saw on the [library-ocpp](https://github.com/monta-app/library-ocpp/pull/10) project that running

`./gradlew --no-daemon :test` did not trigger the test targets in submodules

it needs to be

`./gradlew --no-daemon test`

