### PR TITLE
chore(deploy): bump kubectl version to match the actual kubernetes version

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -332,8 +332,10 @@ jobs:
           curl --proto '=https' --tlsv1.2 -sSfL https://run.linkerd.io/install | sh
       - name: Install kubectl CLI
         shell: bash
+        env:
+          K8S_VERSION: v1.30.10
         run: |
-          curl -LO https://dl.k8s.io/release/v1.28.4/bin/linux/amd64/kubectl
+          curl -LO https://dl.k8s.io/release/{{ env.K8S_VERSION }}/bin/linux/amd64/kubectl
           sudo chmod +x kubectl
       - name: Install Teleport
         uses: teleport-actions/setup@v1


### PR DESCRIPTION
We are on v1.30 in both staging and production.

<img width="452" alt="image" src="https://github.com/user-attachments/assets/8dbf95bd-384b-4167-b289-037af2879cd5" />
<img width="488" alt="image" src="https://github.com/user-attachments/assets/be1edadb-c09d-4b15-9055-7d28b9d0a2eb" />
