### PR TITLE
revert: "chore: Cleanup status check logic in `deploy.yaml`"

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -310,7 +310,7 @@ jobs:
           slack-message-id: ${{ needs.init.outputs.slack-message-id }}
 
   update-open-api-spec:
-    if: ${{ inputs.upload-open-api }}
+    if: ${{ ! failure() && ! cancelled() && inputs.upload-open-api }}
     name: Update OpenAPI Spec
     needs: [ init, test, build ]
     runs-on: ubuntu-latest
@@ -649,7 +649,7 @@ jobs:
   push-manifest-list:
     name: Push Manifest
     needs: [ init, build, test ]
-    if: success()
+    if: ${{ ! failure() && ! cancelled() }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -733,7 +733,7 @@ jobs:
           slack-message-id: ${{ needs.init.outputs.slack-message-id }}
 
   deploy_by_push:
-    if: ${{ inputs.push-to-manifests }}
+    if: ${{ ! failure() && ! cancelled() && inputs.push-to-manifests }}
     name: Deploy (push)
     needs:
     - push-manifest-list
@@ -788,7 +788,7 @@ jobs:
           slack-message-id: ${{ needs.init.outputs.slack-message-id }}
 
   deploy_by_argocd:
-    if: ${{ ! inputs.push-to-manifests }}
+    if: ${{ ! failure() && ! cancelled() && ! inputs.push-to-manifests }}
     name: Deploy (ArgoCD)
     needs:
     - push-manifest-list
@@ -837,7 +837,7 @@ jobs:
           slack-message-id: ${{ needs.init.outputs.slack-message-id }}
 
   deploy_ocpp_gateway:
-    if: ${{ inputs.service-identifier == 'ocpp-gateway' }}
+    if: ${{ ! failure() && ! cancelled() && ( inputs.service-identifier == 'ocpp-gateway' || inputs.service-identifier == 'ocpp-v201-gateway' ) }}
     name: Deploy OCPP Gateway
     needs:
     - init


### PR DESCRIPTION
Reverts monta-app/github-workflows#128

When tests are skipped, the push manifest + other steps that require tests aren't run