### PR TITLE
fix: concurrent multi module code uploads

### DIFF
--- a/.github/workflows/code-coverage-kotlin.yaml
+++ b/.github/workflows/code-coverage-kotlin.yaml
@@ -110,7 +110,7 @@ jobs:
       - name: Upload coverage report
         uses: actions/upload-artifact@v4
         with:
-          name: coverage-report
+          name: coverage-report${{ inputs.gradle-module }}
           path: ${{ inputs.kover-report-path }}
           retention-days: 1
   push-coverage-to-server:
@@ -128,7 +128,7 @@ jobs:
         id: download-coverage
         uses: actions/download-artifact@v4
         with:
-          name: coverage-report
+          name: coverage-report${{ inputs.gradle-module }}
       - name: Set coverage report path
         id: coverage-path
         run: |


### PR DESCRIPTION
**Problem**

On matrix builds the upload failed due to a name conflict
```
Error: Failed to CreateArtifact: Received non-retryable error: Failed request: (409) Conflict: an artifact with this name already exists on the workflow run
```
[Example job that failed](https://github.com/monta-app/service-api-gateways/actions/runs/16116155547/job/45470394246)

**Solution**

Make the module name part of the artifact name - if module name is empty it should stay the same.