### PR TITLE
feat: add rollback workflow

### DIFF
--- a/.github/workflows/allow-deploys.yml
+++ b/.github/workflows/allow-deploys.yml
@@ -3,7 +3,7 @@ name: Allow deploys
 on:
   workflow_call:
     inputs:
-      workflow-to-allow:
+      workflow:
         required: true
         type: string
         description: 'Workflow (filename or name) to allow, e.g. "deploy-production.yml".'
@@ -26,7 +26,7 @@ jobs:
         uses: actions/checkout@v4
 
       # Enable CD on merge to main
-      - name: Enable ${{ inputs.workflow-to-allow }} workflow
-        run: gh workflow enable ${{ inputs.workflow-to-allow }}
+      - name: Enable ${{ inputs.workflow }} workflow
+        run: gh workflow enable ${{ inputs.workflow }}
         env:
           GH_TOKEN: ${{ secrets.ADMIN_PAT }}

--- a/.github/workflows/allow-deploys.yml
+++ b/.github/workflows/allow-deploys.yml
@@ -1,0 +1,32 @@
+name: Allow deploys
+
+on:
+  workflow_call:
+    inputs:
+      workflow-to-allow:
+        required: true
+        type: string
+        description: 'Workflow (filename or name) to allow, e.g. "deploy-production.yml".'
+    secrets:
+      ADMIN_PAT:
+        required: true
+        description: 'GitHub PAT to update workflows'
+
+permissions:
+  actions: read
+  contents: read
+  id-token: write
+
+jobs:
+  allow-release:
+    name: Allow release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # Enable CD on merge to main
+      - name: Enable ${{ inputs.workflow-to-allow }} workflow
+        run: gh workflow enable ${{ inputs.workflow-to-allow }}
+        env:
+          GH_TOKEN: ${{ secrets.ADMIN_PAT }}

--- a/.github/workflows/block-deploys.yml
+++ b/.github/workflows/block-deploys.yml
@@ -3,7 +3,7 @@ name: Block deploys
 on:
   workflow_call:
     inputs:
-      workflow-to-block:
+      workflow:
         required: true
         type: string
         description: 'Workflow (filename or name) to block, e.g. "deploy-production.yml".'
@@ -26,8 +26,8 @@ jobs:
         uses: actions/checkout@v4
 
       # Disable CD on merge to main
-      - name: Disable ${{ inputs.workflow-to-block }} workflow
-        run: gh workflow disable ${{ inputs.workflow-to-block }} || true
+      - name: Disable ${{ inputs.workflow }} workflow
+        run: gh workflow disable ${{ inputs.workflow }} || true
         env:
           GH_TOKEN: ${{ secrets.ADMIN_PAT }}
 
@@ -37,10 +37,10 @@ jobs:
         run: sleep 30
 
       # Cancel in-progress deploy jobs
-      - name: Cancel in-progress ${{ inputs.workflow-to-block }} jobs
+      - name: Cancel in-progress ${{ inputs.workflow }} jobs
         run: |
-          for runId in $(gh run list -s in_progress -w ${{ inputs.workflow-to-block }} --json databaseId  | jq --raw-output '.[].databaseId'); do
-            echo "Cancelling in-progress ${{ inputs.workflow-to-block }} job: $runId";
+          for runId in $(gh run list -s in_progress -w ${{ inputs.workflow }} --json databaseId  | jq --raw-output '.[].databaseId'); do
+            echo "Cancelling in-progress ${{ inputs.workflow }} job: $runId";
             gh run cancel $runId;
           done
         env:

--- a/.github/workflows/block-deploys.yml
+++ b/.github/workflows/block-deploys.yml
@@ -31,8 +31,8 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.ADMIN_PAT }}
 
-      # Cancel in-progress deploy jobs
-      - name: Cancel in-progress ${{ inputs.workflow }} jobs
+      # Cancel queued, in-progress, requested, pending or waiting deploy jobs
+      - name: Cancel ${{ inputs.workflow }} jobs
         run: |
           for runId in $(gh run list -w ${{ inputs.workflow }} -a --json databaseId,status -q '.[] | select(.status == "queued" or .status == "in_progress" or .status == "requested" or .status == "waiting" or .status == "pending") | .databaseId'); do
             echo "Cancelling ${{ inputs.workflow }} job: $runId";

--- a/.github/workflows/block-deploys.yml
+++ b/.github/workflows/block-deploys.yml
@@ -31,17 +31,12 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.ADMIN_PAT }}
 
-      # Wait for jobs of started workflow to start before we nuke them
-      - name: Wait for it
-        shell: bash
-        run: sleep 30
-
       # Cancel in-progress deploy jobs
       - name: Cancel in-progress ${{ inputs.workflow }} jobs
         run: |
-          for runId in $(gh run list -s in_progress -w ${{ inputs.workflow }} --json databaseId  | jq --raw-output '.[].databaseId'); do
-            echo "Cancelling in-progress ${{ inputs.workflow }} job: $runId";
-            gh run cancel $runId;
+          for runId in $(gh run list -w ${{ inputs.workflow }} -a --json databaseId,status -q '.[] | select(.status == "queued" or .status == "in_progress" or .status == "requested" or .status == "waiting" or .status == "pending") | .databaseId'); do
+            echo "Cancelling ${{ inputs.workflow }} job: $runId";
+            gh run cancel $runId || echo "Could not cancel job $runId. Status might have just changed." ;
           done
         env:
           GH_TOKEN: ${{ secrets.ADMIN_PAT }}

--- a/.github/workflows/block-deploys.yml
+++ b/.github/workflows/block-deploys.yml
@@ -1,0 +1,47 @@
+name: Block deploys
+
+on:
+  workflow_call:
+    inputs:
+      workflow-to-block:
+        required: true
+        type: string
+        description: 'Workflow (filename or name) to block, e.g. "deploy-production.yml".'
+    secrets:
+      ADMIN_PAT:
+        required: true
+        description: 'GitHub PAT to update workflows'
+
+permissions:
+  actions: read
+  contents: read
+  id-token: write
+
+jobs:
+  disable-deploy-flows:
+    name: Disable and cancel deploy
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # Disable CD on merge to main
+      - name: Disable ${{ inputs.workflow-to-block }} workflow
+        run: gh workflow disable ${{ inputs.workflow-to-block }} || true
+        env:
+          GH_TOKEN: ${{ secrets.ADMIN_PAT }}
+
+      # Wait for jobs of started workflow to start before we nuke them
+      - name: Wait for it
+        shell: bash
+        run: sleep 30
+
+      # Cancel in-progress deploy jobs
+      - name: Cancel in-progress ${{ inputs.workflow-to-block }} jobs
+        run: |
+          for runId in $(gh run list -s in_progress -w ${{ inputs.workflow-to-block }} --json databaseId  | jq --raw-output '.[].databaseId'); do
+            echo "Cancelling in-progress ${{ inputs.workflow-to-block }} job: $runId";
+            gh run cancel $runId;
+          done
+        env:
+          GH_TOKEN: ${{ secrets.ADMIN_PAT }}

--- a/.github/workflows/rollback.yml
+++ b/.github/workflows/rollback.yml
@@ -65,6 +65,13 @@ jobs:
           path: 'kube-manifests'
           token: ${{ secrets.MANIFEST_REPO_PAT }}
 
+      - name: Checkout branch
+        uses: actions/checkout@v4
+        with:
+          path: 'rollback-repo'
+          fetch-depth: 0
+          filter: 'blob:none'
+
       - name: Find short commit to roll back to
         id: find-short-commit
         working-directory: ./kube-manifests/apps/${{ inputs.service-identifier }}/${{ inputs.environment }}/cluster
@@ -73,12 +80,6 @@ jobs:
           INPUT_COMMIT_SHA_SHORT=${{ github.event.inputs.commit-sha }}
           ROLLBACK_COMMIT_SHA_SHORT=${INPUT_COMMIT_SHA_SHORT:-$PREVIOUS_COMMIT_SHA_SHORT}
           echo "rollback_commit_sha_short=$ROLLBACK_COMMIT_SHA_SHORT" >> $GITHUB_OUTPUT
-
-      - name: Checkout branch
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ steps.find-short-commit.outputs.rollback_commit_sha_short }}
-          path: 'rollback-repo'
 
       - name: Find full commit to roll back to
         id: find-commit

--- a/.github/workflows/rollback.yml
+++ b/.github/workflows/rollback.yml
@@ -28,13 +28,17 @@ on:
         type: boolean
         default: false
         description: 'Set to true to show rollback without pushing. Will also disable slack.'
+      block-deploy-workflow:
+        required: false
+        type: string
+        description: 'Name/filename of deploy workflow to block, e.g. "deploy-production.yml".'
     secrets:
       SLACK_WEBHOOK:
         required: true
         description: 'Slack webhook'
-      MANIFEST_REPO_PAT:
+      ADMIN_PAT:
         required: true
-        description: 'GitHub PAT to commit/push to kube-manifests repo'
+        description: 'GitHub PAT to update workflows and push to kube-manifests repo'
 
 permissions:
   actions: read
@@ -83,7 +87,7 @@ jobs:
         with:
           repository: monta-app/kube-manifests
           path: 'kube-manifests'
-          token: ${{ secrets.MANIFEST_REPO_PAT }}
+          token: ${{ secrets.ADMIN_PAT }}
 
       - name: Update app config for ${{ inputs.environment }}
         working-directory: ./kube-manifests/apps/${{ inputs.service-identifier }}/${{ inputs.environment }}/app
@@ -115,6 +119,16 @@ jobs:
         if: ${{ !inputs.dry-run }}
         uses: ad-m/github-push-action@master
         with:
-          github_token: ${{ secrets.MANIFEST_REPO_PAT }}
+          github_token: ${{ secrets.ADMIN_PAT }}
           directory: './kube-manifests'
           repository: 'monta-app/kube-manifests'
+
+  block-deploys:
+    name: Block Deploys
+    if: ${{ inputs.block-deploy-workflow }}
+    uses: ./.github/workflows/block-deploys.yml
+    with:
+      workflow-to-block: ${{ inputs.block-deploy-workflow }}
+    secrets:
+      ADMIN_PAT: ${{ secrets.ADMIN_PAT }}
+

--- a/.github/workflows/rollback.yml
+++ b/.github/workflows/rollback.yml
@@ -23,6 +23,11 @@ on:
         required: true
         type: string
         description: 'The deploy environment, one of "dev", "staging", "production".'
+      dry-run:
+        required: false
+        type: boolean
+        default: false
+        description: 'Set to true to show rollback without pushing. Will also disable slack.'
     secrets:
       SLACK_WEBHOOK:
         required: true
@@ -39,6 +44,7 @@ permissions:
 jobs:
   slackNotification:
     name: Send Slack notification
+    if: ${{ !inputs.dry-run }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -58,36 +64,26 @@ jobs:
     name: Deploy rollback
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout branch
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - name: Find commit to roll back to
+        id: find-commit
+        run: |
+          PREVIOUS_COMMIT_SHA=$(git rev-parse HEAD^)
+          INPUT_COMMIT_SHA=${{ github.event.inputs.commit-sha }}
+          ROLLBACK_COMMIT_SHA=${INPUT_COMMIT_SHA:-$PREVIOUS_COMMIT_SHA}
+          echo "Rolling back to commit: $ROLLBACK_COMMIT_SHA"
+          echo "rollback_commit_sha=$ROLLBACK_COMMIT_SHA" >> $GITHUB_OUTPUT
+
       - name: Check out kube-manifests
         uses: actions/checkout@v4
         with:
           repository: monta-app/kube-manifests
           path: 'kube-manifests'
           token: ${{ secrets.MANIFEST_REPO_PAT }}
-
-      - name: Checkout branch
-        uses: actions/checkout@v4
-        with:
-          path: 'rollback-repo'
-          fetch-depth: 0
-          filter: 'blob:none'
-
-      - name: Find short commit to roll back to
-        id: find-short-commit
-        working-directory: ./kube-manifests/apps/${{ inputs.service-identifier }}/${{ inputs.environment }}/cluster
-        run: |
-          PREVIOUS_COMMIT_SHA_SHORT=$(yq e .previousHash config.yaml)
-          INPUT_COMMIT_SHA_SHORT=${{ github.event.inputs.commit-sha }}
-          ROLLBACK_COMMIT_SHA_SHORT=${INPUT_COMMIT_SHA_SHORT:-$PREVIOUS_COMMIT_SHA_SHORT}
-          echo "rollback_commit_sha_short=$ROLLBACK_COMMIT_SHA_SHORT" >> $GITHUB_OUTPUT
-
-      - name: Find full commit to roll back to
-        id: find-commit
-        working-directory: ./rollback-repo
-        run: |
-          PREVIOUS_COMMIT_SHA=$(git rev-parse ${{ steps.find-short-commit.outputs.rollback_commit_sha_short }})
-          echo "Rolling back to commit: $ROLLBACK_COMMIT_SHA"
-          echo "rollback_commit_sha=$ROLLBACK_COMMIT_SHA" >> $GITHUB_OUTPUT
 
       - name: Update app config for ${{ inputs.environment }}
         working-directory: ./kube-manifests/apps/${{ inputs.service-identifier }}/${{ inputs.environment }}/app
@@ -109,11 +105,14 @@ jobs:
       - name: Commit
         working-directory: ./kube-manifests
         run: |
+          echo "Committing changes:"
+          git diff
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
           git commit -am "Bump docker tags for ${{ inputs.service-identifier }} on ${{ inputs.environment }} (rollback)"
 
       - name: Push
+        if: ${{ !inputs.dry-run }}
         uses: ad-m/github-push-action@master
         with:
           github_token: ${{ secrets.MANIFEST_REPO_PAT }}

--- a/.github/workflows/rollback.yml
+++ b/.github/workflows/rollback.yml
@@ -68,7 +68,7 @@ jobs:
 
   block-deploys:
     name: Block Deploys
-    if: ${{ inputs.block-workflow }}
+    if: ${{ inputs.block-workflow && !inputs.dry-run }}
     uses: ./.github/workflows/block-deploys.yml
     with:
       workflow: ${{ inputs.block-workflow }}
@@ -77,6 +77,7 @@ jobs:
 
   push-manifest:
     needs: block-deploys
+    if: ${{ !cancelled() && (needs.block-deploys.result == 'success' || needs.block-deploys.result == 'skipped') }}
     name: Deploy rollback
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/rollback.yml
+++ b/.github/workflows/rollback.yml
@@ -28,10 +28,10 @@ on:
         type: boolean
         default: false
         description: 'Set to true to show rollback without pushing. Will also disable slack.'
-      block-deploy-workflow:
+      block-workflow:
         required: false
         type: string
-        description: 'Name/filename of deploy workflow to block, e.g. "deploy-production.yml".'
+        description: 'Name/filename of workflow to block, e.g. "deploy-production.yml".'
     secrets:
       SLACK_WEBHOOK:
         required: true
@@ -125,10 +125,10 @@ jobs:
 
   block-deploys:
     name: Block Deploys
-    if: ${{ inputs.block-deploy-workflow }}
+    if: ${{ inputs.block-workflow }}
     uses: ./.github/workflows/block-deploys.yml
     with:
-      workflow-to-block: ${{ inputs.block-deploy-workflow }}
+      workflow: ${{ inputs.block-workflow }}
     secrets:
       ADMIN_PAT: ${{ secrets.ADMIN_PAT }}
 

--- a/.github/workflows/rollback.yml
+++ b/.github/workflows/rollback.yml
@@ -23,6 +23,13 @@ on:
         required: true
         type: string
         description: 'The deploy environment, one of "dev", "staging", "production".'
+    secrets:
+      SLACK_WEBHOOK:
+        required: true
+        description: 'Slack webhook'
+      MANIFEST_REPO_PAT:
+        required: true
+        description: 'GitHub PAT to commit/push to kube-manifests repo'
 
 permissions:
   actions: read
@@ -56,7 +63,7 @@ jobs:
         with:
           repository: monta-app/kube-manifests
           path: 'kube-manifests'
-          token: ${{ secrets.PAT }}
+          token: ${{ secrets.MANIFEST_REPO_PAT }}
 
       - name: Find short commit to roll back to
         id: find-short-commit
@@ -108,6 +115,6 @@ jobs:
       - name: Push
         uses: ad-m/github-push-action@master
         with:
-          github_token: ${{ secrets.PAT }}
+          github_token: ${{ secrets.MANIFEST_REPO_PAT }}
           directory: './kube-manifests'
           repository: 'monta-app/kube-manifests'

--- a/.github/workflows/rollback.yml
+++ b/.github/workflows/rollback.yml
@@ -4,9 +4,9 @@ on:
   workflow_call:
     inputs:
       commit-sha:
-        description: 'Commit to roll back to. Defaults to the previously deployed commit.'
         required: false
         type: string
+        description: 'Commit to roll back to. Defaults to the previously deployed commit.'
       service-name:
         required: true
         type: string

--- a/.github/workflows/rollback.yml
+++ b/.github/workflows/rollback.yml
@@ -6,7 +6,7 @@ on:
       commit-sha:
         required: false
         type: string
-        description: 'Commit to roll back to. Defaults to the previously deployed commit.'
+        description: 'Commit to roll back to. Defaults to HEAD^.'
       service-name:
         required: true
         type: string

--- a/.github/workflows/rollback.yml
+++ b/.github/workflows/rollback.yml
@@ -1,0 +1,113 @@
+name: Rollback
+
+on:
+  workflow_call:
+    inputs:
+      commit-sha:
+        description: 'Commit to roll back to. Defaults to the previously deployed commit.'
+        required: false
+        type: string
+      service-name:
+        required: true
+        type: string
+        description: 'Proper name for your service i.e OCPP Service, Vehicle Service'
+      service-identifier:
+        required: true
+        type: string
+        description: 'Identifier of the service being released i.e ocpp, vehicle, server, wallet.'
+      slack-channel:
+        required: true
+        type: string
+        description: 'Slack channel in which to announce triggered rollbacks.'
+      environment:
+        required: true
+        type: string
+        description: 'The deploy environment, one of "dev", "staging", "production".'
+
+permissions:
+  actions: read
+  contents: read
+  id-token: write
+
+jobs:
+  slackNotification:
+    name: Send Slack notification
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Slack Notification
+        uses: rtCamp/action-slack-notify@v2
+        env:
+          MSG_MINIMAL: true #'ref,commit'
+          SLACK_CHANNEL: ${{ inputs.slack-channel }}
+          SLACK_ICON: 'https://avatars.slack-edge.com/2020-10-24/1463567065009_39967124f549f50e3faf_512.png'
+          SLACK_MESSAGE: "Rollback of ${{ inputs.service-name }} on ${{ inputs.environment }} in progress"
+          SLACK_TITLE: "Triggered by ${{ github.triggering_actor }}. :back: :double_vertical_bar:"
+          SLACK_USERNAME: 'Monta Bot'
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          SLACK_FOOTER: 'Powered by Monta! #EVBetter'
+
+  push-manifest:
+    name: Deploy rollback
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out kube-manifests
+        uses: actions/checkout@v4
+        with:
+          repository: monta-app/kube-manifests
+          path: 'kube-manifests'
+          token: ${{ secrets.PAT }}
+
+      - name: Find short commit to roll back to
+        id: find-short-commit
+        working-directory: ./kube-manifests/apps/${{ inputs.service-identifier }}/${{ inputs.environment }}/cluster
+        run: |
+          PREVIOUS_COMMIT_SHA_SHORT=$(yq e .previousHash config.yaml)
+          INPUT_COMMIT_SHA_SHORT=${{ github.event.inputs.commit-sha }}
+          ROLLBACK_COMMIT_SHA_SHORT=${INPUT_COMMIT_SHA_SHORT:-$PREVIOUS_COMMIT_SHA_SHORT}
+          echo "rollback_commit_sha_short=$ROLLBACK_COMMIT_SHA_SHORT" >> $GITHUB_OUTPUT
+
+      - name: Checkout branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.find-short-commit.outputs.rollback_commit_sha_short }}
+          path: 'rollback-repo'
+
+      - name: Find full commit to roll back to
+        id: find-commit
+        working-directory: ./rollback-repo
+        run: |
+          PREVIOUS_COMMIT_SHA=$(git rev-parse ${{ steps.find-short-commit.outputs.rollback_commit_sha_short }})
+          echo "Rolling back to commit: $ROLLBACK_COMMIT_SHA"
+          echo "rollback_commit_sha=$ROLLBACK_COMMIT_SHA" >> $GITHUB_OUTPUT
+
+      - name: Update app config for ${{ inputs.environment }}
+        working-directory: ./kube-manifests/apps/${{ inputs.service-identifier }}/${{ inputs.environment }}/app
+        run: |
+          ROLLBACK_COMMIT_SHA=${{ steps.find-commit.outputs.rollback_commit_sha }}
+          sed -i "s/tag: .*/tag: $ROLLBACK_COMMIT_SHA/" values.yaml
+          sed -i "s/revision: .*/revision: ${ROLLBACK_COMMIT_SHA::8}/" values.yaml
+
+      - name: Update cluster config for ${{ inputs.environment }}
+        shell: bash
+        working-directory: ./kube-manifests/apps/${{ inputs.service-identifier }}/${{ inputs.environment }}/cluster
+        run: |
+          ROLLBACK_COMMIT_SHA=${{ steps.find-commit.outputs.rollback_commit_sha }}
+          # Update previousHash
+          previousHash=$(yq e .currentHash config.yaml) yq e '.previousHash = strenv(previousHash)' -i config.yaml
+          # Update currentHash
+          currentHash=${ROLLBACK_COMMIT_SHA::8} yq e '.currentHash = strenv(currentHash)' -i config.yaml
+
+      - name: Commit
+        working-directory: ./kube-manifests
+        run: |
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+          git commit -am "Bump docker tags for ${{ inputs.service-identifier }} on ${{ inputs.environment }} (rollback)"
+
+      - name: Push
+        uses: ad-m/github-push-action@master
+        with:
+          github_token: ${{ secrets.PAT }}
+          directory: './kube-manifests'
+          repository: 'monta-app/kube-manifests'

--- a/.github/workflows/rollback.yml
+++ b/.github/workflows/rollback.yml
@@ -40,6 +40,8 @@ on:
         required: true
         description: 'GitHub PAT to update workflows and push to kube-manifests repo'
 
+
+
 permissions:
   actions: read
   contents: read
@@ -64,7 +66,17 @@ jobs:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
           SLACK_FOOTER: 'Powered by Monta! #EVBetter'
 
+  block-deploys:
+    name: Block Deploys
+    if: ${{ inputs.block-workflow }}
+    uses: ./.github/workflows/block-deploys.yml
+    with:
+      workflow: ${{ inputs.block-workflow }}
+    secrets:
+      ADMIN_PAT: ${{ secrets.ADMIN_PAT }}
+
   push-manifest:
+    needs: block-deploys
     name: Deploy rollback
     runs-on: ubuntu-latest
     steps:
@@ -122,13 +134,3 @@ jobs:
           github_token: ${{ secrets.ADMIN_PAT }}
           directory: './kube-manifests'
           repository: 'monta-app/kube-manifests'
-
-  block-deploys:
-    name: Block Deploys
-    if: ${{ inputs.block-workflow }}
-    uses: ./.github/workflows/block-deploys.yml
-    with:
-      workflow: ${{ inputs.block-workflow }}
-    secrets:
-      ADMIN_PAT: ${{ secrets.ADMIN_PAT }}
-


### PR DESCRIPTION
Wallet and PHP both have nice rollback workflows. This adds the simpler wallet version, made generic, but with the option to also block deploys when run.

Tested here: https://github.com/monta-app/service-openadr/actions/workflows/rollback.yml

See https://github.com/monta-app/service-openadr/pull/195/files for how to use.