### PR TITLE
fix: Inject lokalise values into build as docker secrets

### DIFF
--- a/.github/workflows/component-build.yml
+++ b/.github/workflows/component-build.yml
@@ -69,10 +69,10 @@ on:
         description: "AWS CDN Secret Access Key, this value is injected into the secrets of a docker image"
       LOKALISE_TOKEN:
         required: false
-        description: 'Lokalise token for Lokalise API'
+        description: 'Lokalise token for Lokalise API, this value is injected into the secrets of a docker image'
       LOKALISE_PROJECT_ID:
         required: false
-        description: 'Lokalise project ID for Lokalise API'
+        description: 'Lokalise project ID for Lokalise API, this value is injected into the secrets of a docker image'
     outputs:
       image-tag:
         description: 'The image tag that was built'
@@ -169,6 +169,8 @@ jobs:
             SENTRY_AUTH_TOKEN=${{ secrets.SENTRY_AUTH_TOKEN }}
             AWS_CDN_ACCESS_KEY_ID=${{ secrets.AWS_CDN_ACCESS_KEY_ID }}
             AWS_CDN_SECRET_ACCESS_KEY=${{ secrets.AWS_CDN_SECRET_ACCESS_KEY }}
+            LOKALISE_TOKEN=${{ secrets.LOKALISE_TOKEN }}
+            LOKALISE_PROJECT_ID=${{ secrets.LOKALISE_PROJECT_ID }}
   create-manifest:
     name: Create Multi-Arch Manifest
     needs: build


### PR DESCRIPTION
This fixes a problem with the previous approach and instead injects the lokalise values into the build as docker secrets. This also improves the security.