### PR TITLE
feat: Build and deploy on multi-module project

### DIFF
--- a/.github/workflows/component-build.yml
+++ b/.github/workflows/component-build.yml
@@ -23,6 +23,10 @@ on:
         required: true
         type: string
         description: 'Identifier of the service being released i.e ocpp, vehicle, server, wallet.'
+      gradle-module:
+        required: false
+        type: string
+        description: 'Name of the Gradle module'
       region:
         required: false
         type: string
@@ -154,7 +158,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
-          file: ./${{ inputs.docker-file-name }}
+          file: ./${{ inputs.gradle-module && format('{0}/{1}', inputs.gradle-module, inputs.docker-file-name) || inputs.docker-file-name }}
           push: true
           no-cache: true
           build-args: |

--- a/.github/workflows/deploy-kotlin.yml
+++ b/.github/workflows/deploy-kotlin.yml
@@ -27,7 +27,7 @@ on:
       gradle-module:
         required: false
         type: string
-        description: 'Name of the Gradle module being tested'
+        description: 'Name of the Gradle module'
       java-version:
         required: false
         type: string
@@ -166,6 +166,7 @@ jobs:
       service-name: ${{ inputs.service-name }}
       service-emoji: ${{ inputs.service-emoji }}
       service-identifier: ${{ inputs.service-identifier }}
+      gradle-module: ${{ inputs.gradle-module }}
       region: ${{ inputs.region }}
       docker-file-name: ${{ inputs.docker-file-name }}
       additional-build-args: ${{ inputs.additional-build-args }}


### PR DESCRIPTION
Use `gradle-module` to set path for `Dockerfile` in multi-module project.

With these changes, I got the deploy flow working on the feature service (staging so far), which is a multi-module project, where `Dockerfile` doesn't reside in the root directory.