### PR TITLE
fix: Add always() to run-tests conditional

### DIFF
--- a/.github/workflows/deploy-kotlin.yml
+++ b/.github/workflows/deploy-kotlin.yml
@@ -141,7 +141,7 @@ jobs:
   test:
     name: Test
     needs: initialize
-    if: inputs.run-tests && needs.initialize.result == 'success'
+    if: always() && inputs.run-tests && needs.initialize.result == 'success'
     uses: ./.github/workflows/component-test-kotlin.yml
     with:
       runner-size: ${{ inputs.runner-size }}


### PR DESCRIPTION
The run-tests default does not seem to work correctly, this is an attempt at making it behave.