### PR TITLE
fix: (deploy-kotlin) Made the change-log job dependent on the tag job…

### DIFF
--- a/.github/workflows/deploy-kotlin.yml
+++ b/.github/workflows/deploy-kotlin.yml
@@ -200,7 +200,7 @@ jobs:
       prefix: ${{ inputs.release-tag-prefix }}
   create-changelog:
     name: Create and Publish Changelog
-    needs: deploy
+    needs: create-release-tag
     if: always() && inputs.enable-changelog && needs.deploy.result == 'success'
     runs-on: ubuntu-latest
     timeout-minutes: 5


### PR DESCRIPTION
… to ensure the tag is created before trying to find it

See https://monta-app01.slack.com/archives/C095107NE01/p1756377713513759?thread_ts=1756299245.675239&cid=C095107NE01