### PR TITLE
feat: Changed the default setting for linkerd services profiles to `true`

### DIFF
--- a/.github/workflows/deploy-kotlin.yml
+++ b/.github/workflows/deploy-kotlin.yml
@@ -59,7 +59,7 @@ on:
       enable-release-tag:
         required: false
         type: boolean
-        default: ${{ inputs.stage == 'production' }}
+        default: false
         description: 'Enable automatic release tag creation on workflow_dispatch'
       release-tag-prefix:
         required: false
@@ -68,7 +68,7 @@ on:
       enable-changelog:
         required: false
         type: boolean
-        default: ${{ inputs.stage == 'production' }}
+        default: false
         description: 'Enable changelog generation after deployment'
       changelog-tag-pattern:
         required: false


### PR DESCRIPTION
This will enable linkerd services profiles for all github actions that uses the `deploy-kotlin.yml` workflow.
  * can be disabled on individual projects by setting `update-service-profile: false`

## Additional observations

In production deployments that are both being triggered as a workflow_dispatch AND based on manual tagging. I.e. like this

```
name: Deploy Production

on:
  push:
    tags:
      - "*"
  workflow_dispatch:
```

this is the recommended setting for `enable-release-tag` - i.e. setting it to true only if the workflow was triggered based on the project being run without a tag already being present

```
enable-release-tag: ${{ github.event_name == 'workflow_dispatch' }}
```