### PR TITLE
feat: update deploy-ocpp-gateway to use internal cluster endpoint

### DIFF
--- a/.github/actions/deploy-ocpp-gateway/action.yml
+++ b/.github/actions/deploy-ocpp-gateway/action.yml
@@ -27,7 +27,7 @@ runs:
         STAGE: ${{ inputs.stage }}
       run: |
         if [[ $STAGE =~ dev|staging ]]; then
-          INFRA_PORTAL_HOSTNAME="infra-portal.staging.monta.app"
+          INFRA_PORTAL_HOSTNAME="infra-portal.internal.monta.app"
         else
           INFRA_PORTAL_HOSTNAME="infra-portal.monta.app"
         fi
@@ -37,10 +37,12 @@ runs:
       run: |
         if [[ ${{ inputs.stage }} =~ dev|staging ]]; then
           cluster=staging
+          path_prefix="/api/public"
         else
           cluster=production
+          path_prefix=""
         fi
-        response_code=$(curl --write-out '%{http_code}' --silent -o resp_body.txt -X POST -H "Authorization: Bearer ${{ inputs.infra-portal-token }}" -H "Content-Type: application/json" -d '{"commitHash": "'"${{ github.sha }}"'", "buildNumber": "'"${{ github.run_number }}"'", "awsAccountId": "'"${{ inputs.aws-account-id }}"'", "replicas": ${{ inputs.ocpp-gateway-replicas }}}' https://${{ steps.set-infra-portal-server.outputs.infra-portal-hostname }}/ocpp-${cluster}/${{ inputs.service-identifier }}-${{ inputs.stage }}/create-gateway-release)
+        response_code=$(curl --write-out '%{http_code}' --silent -o resp_body.txt -X POST -H "Authorization: Bearer ${{ inputs.infra-portal-token }}" -H "Content-Type: application/json" -d '{"commitHash": "'"${{ github.sha }}"'", "buildNumber": "'"${{ github.run_number }}"'", "awsAccountId": "'"${{ inputs.aws-account-id }}"'", "replicas": ${{ inputs.ocpp-gateway-replicas }}}' https://${{ steps.set-infra-portal-server.outputs.infra-portal-hostname }}${path_prefix}/ocpp-${cluster}/${{ inputs.service-identifier }}-${{ inputs.stage }}/create-gateway-release)
         if [[ $response_code != "200" ]]; then
           echo "::error::$(cat resp_body.txt)"
           exit 1


### PR DESCRIPTION
## Summary
- Point staging deployments at `infra-portal.internal.monta.app` instead of `infra-portal.staging.monta.app` (the old V1 deployment)
- Add `/api/public` path prefix for staging so the request reaches the new V2 `create-gateway-release` endpoint, which is exposed through the ingress only under that prefix

This is part of the OCPP Gateway Releaser migration from V1 to V2. The new V2 endpoint requires the `/api/public` prefix so it passes through the ingress, and uses `infra-portal.internal.monta.app` (the internal V2 deployment).

## Test plan
- [ ] Trigger an OCPP Gateway staging deployment and verify the `create-gateway-release` call returns 200
- [ ] Confirm the `INFRA_PORTAL_TOKEN_STAGING` secret in `service-ocpp` matches the plaintext value of the `OCPPGW_RELEASE_TOKEN` sealed secret in infra-portal

🤖 Generated with [Claude Code](https://claude.com/claude-code)