### PR TITLE
fix(workflows): use unique artifact names to prevent matrix job collisions

### DIFF
--- a/.github/workflows/code-coverage-kotlin.yml
+++ b/.github/workflows/code-coverage-kotlin.yml
@@ -125,7 +125,7 @@ jobs:
       - name: Upload coverage report
         uses: actions/upload-artifact@v7
         with:
-          name: coverage-report
+          name: coverage-report-${{ inputs.service-name }}
           path: ${{ inputs.kover-report-path }}
           retention-days: 1
   push-coverage-to-server:
@@ -143,7 +143,7 @@ jobs:
         id: download-coverage
         uses: actions/download-artifact@v8
         with:
-          name: coverage-report
+          name: coverage-report-${{ inputs.service-name }}
       - name: Set coverage report path
         id: coverage-path
         run: |

--- a/.github/workflows/sonar-cloud.yml
+++ b/.github/workflows/sonar-cloud.yml
@@ -84,7 +84,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v7
         with:
-          name: build-reports
+          name: build-reports-${{ inputs.gradle-module || 'root' }}
           path: |
             **/build/reports/kover/html/**
             **/build/reports/problems/**


### PR DESCRIPTION
## Summary

- `code-coverage-kotlin.yml`: artifact names `coverage-report` → `coverage-report-{service-name}` (both upload and download)
- `sonar-cloud.yml`: artifact name `build-reports` → `build-reports-{gradle-module}`

## Root cause

Both workflows use hardcoded artifact names. When called from a matrix in `service-api-gateways/.github/workflows/code-analysis.yml`, all 4 module jobs run concurrently under the same workflow run and race to create the same artifact name, producing:

```
Error: Failed to CreateArtifact: (409) Conflict: an artifact with this name already exists on the workflow run
```

## Why this fix works

Each matrix job passes a unique `service-name` / `gradle-module` input, so the artifact names are now unique per job. The upload/download pair in `code-coverage-kotlin.yml` both use `service-name`, so they still refer to the same artifact within a single invocation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)