### PR TITLE
chore: add AI PR Review to github-workflows self-CI

### DIFF
--- a/.github/workflows/ai-pr-review.yml
+++ b/.github/workflows/ai-pr-review.yml
@@ -1,0 +1,16 @@
+name: AI PR Review
+
+on:
+  pull_request:
+    types: [opened, ready_for_review, synchronize]
+  issue_comment:
+    types: [created]
+
+jobs:
+  ai-review:
+    uses: monta-app/ai-standards/.github/workflows/ai-pr-review.yml@main
+    with:
+      run-on-drafts: true
+    secrets:
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+      AI_REVIEWER_SECRET_KEY: ${{ secrets.AI_REVIEWER_SECRET_KEY }}


### PR DESCRIPTION
## Summary

Adds the same `AI PR Review` workflow we run on the service repos (`service-control`, `service-vehicle`, `service-api-gateways`, etc.) to this repo's own self-CI, so PRs against the shared workflows also get an automated code review.

## Why here too

This repo's CI currently only runs `actionlint` (syntactic). Every change here ripples to every Monta service that consumes the shared workflows, so an extra layer of intent/content review on top of `actionlint` has obvious value:

- Catch unintended behavior changes in widely-shared workflows
- Surface security implications of permission/secret/runner changes
- Spot accidental hardcoding (e.g., the `--max-workers=2` discussion on #279 that prompted this)

## What it adds

A single new file: `.github/workflows/ai-pr-review.yml`. Pattern matches `service-vehicle` and `service-api-gateways` plus `run-on-drafts: true`:

```yaml
name: AI PR Review

on:
  pull_request:
    types: [opened, ready_for_review, synchronize]
  issue_comment:
    types: [created]

jobs:
  ai-review:
    uses: monta-app/ai-standards/.github/workflows/ai-pr-review.yml@main
    with:
      run-on-drafts: true
    secrets:
      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
      AI_REVIEWER_SECRET_KEY: ${{ secrets.AI_REVIEWER_SECRET_KEY }}
```

`run-on-drafts: true` is intentional for this repo specifically — changes here usually start as drafts while we test against downstream service repos before promoting them. We want the AI review during that draft phase, not just after promotion.

## Prerequisites

The workflow expects `ANTHROPIC_API_KEY` and `AI_REVIEWER_SECRET_KEY` secrets to be available. If they're already configured at the org level (which is how the service repos pick them up), this should "just work" the moment the PR merges. If not, the org admin will need to grant this repo access to those secrets.

## Test plan

- [ ] After merge, open a tiny draft test PR and confirm the `ai-review / AI Review` check shows up and runs (not just on ready-for-review)

🤖 Generated with [Claude Code](https://claude.com/claude-code)