### PR TITLE
feat: add FARO_API_KEY build secret for source-map upload

### DIFF
--- a/.github/workflows/component-build.yml
+++ b/.github/workflows/component-build.yml
@@ -70,6 +70,9 @@ on:
       SENTRY_AUTH_TOKEN:
         required: false
         description: "Sentry Auth Token, this value is injected into the secrets of a docker image"
+      FARO_API_KEY:
+        required: false
+        description: "Grafana Faro API key for source-map upload, this value is injected into the secrets of a docker image"
       AWS_CDN_ACCESS_KEY_ID:
         required: false
         description: "AWS CDN Secret Access ID, this value is injected into the secrets of a docker image"
@@ -202,6 +205,7 @@ jobs:
             GHL_USERNAME=${{ secrets.GHL_USERNAME }}
             GHL_PASSWORD=${{ secrets.GHL_PASSWORD }}
             SENTRY_AUTH_TOKEN=${{ secrets.SENTRY_AUTH_TOKEN }}
+            FARO_API_KEY=${{ secrets.FARO_API_KEY }}
             AWS_CDN_ACCESS_KEY_ID=${{ secrets.AWS_CDN_ACCESS_KEY_ID }}
             AWS_CDN_SECRET_ACCESS_KEY=${{ secrets.AWS_CDN_SECRET_ACCESS_KEY }}
             LOKALISE_TOKEN=${{ secrets.LOKALISE_TOKEN }}

--- a/.github/workflows/deploy-generic-v2.yml
+++ b/.github/workflows/deploy-generic-v2.yml
@@ -89,6 +89,9 @@ on:
       SENTRY_AUTH_TOKEN:
         required: false
         description: 'Sentry auth token, passed as Docker build secret'
+      FARO_API_KEY:
+        required: false
+        description: 'Grafana Faro API key for source-map upload, passed as Docker build secret'
       AWS_CDN_ACCESS_KEY_ID:
         required: false
         description: 'CDN access key ID for S3 access, injected into Docker image'
@@ -168,6 +171,7 @@ jobs:
       AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID }}
       SLACK_APP_TOKEN: ${{ secrets.SLACK_APP_TOKEN }}
       SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+      FARO_API_KEY: ${{ secrets.FARO_API_KEY }}
       AWS_CDN_ACCESS_KEY_ID: ${{ secrets.AWS_CDN_ACCESS_KEY_ID }}
       AWS_CDN_SECRET_ACCESS_KEY: ${{ secrets.AWS_CDN_SECRET_ACCESS_KEY }}
       NEXT_SERVER_ACTIONS_ENCRYPTION_KEY: ${{ secrets.NEXT_SERVER_ACTIONS_ENCRYPTION_KEY }}


### PR DESCRIPTION
## Summary

Wires a new optional `FARO_API_KEY` through the reusable workflow chain so service repos can upload Grafana Faro source maps during their Docker build. Mirrors the existing `SENTRY_AUTH_TOKEN` plumbing exactly — no behavior change for callers that don't pass the new secret.

- **`deploy-generic-v2.yml`** — declare `FARO_API_KEY` as an optional secret input and forward it to the build component (4 lines).
- **`component-build.yml`** — declare `FARO_API_KEY` as an optional secret input and inject it into the `docker/build-push-action` secrets list (4 lines).

Each downstream Dockerfile decides whether to consume it via `--mount=type=secret,id=FARO_API_KEY,required=false`. Repos that haven't onboarded Faro see no change — the secret is optional and the Docker mount is `required=false`.

## Caller-side usage

In a service repo's deploy workflow:

```yaml
secrets:
  # ... existing entries ...
  FARO_API_KEY: ${{ secrets.FARO_API_KEY }}
```

First consumer is `monorepo-typescript`'s `frontend-hub` deploy, which uses `@grafana/faro-rollup-plugin` in its Vite build to upload source maps so Faro errors symbolicate to readable source lines in Grafana Cloud Frontend Observability.

## Test plan

- [ ] Re-run a deploy workflow in `monorepo-typescript` (e.g. `deploy-hub-staging.yml`) without setting `FARO_API_KEY` → build passes, no behavior change (confirms optional path)
- [ ] Re-run with `FARO_API_KEY` set → Faro source maps appear in Grafana Cloud's Frontend Observability app for the `Hub` app, errors symbolicate to real source lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)