### PR TITLE
feat: add opt-in BuildKit cache tuning inputs (persistent-builder, buildkit-cache-mode)

### DIFF
--- a/.github/workflows/component-build.yml
+++ b/.github/workflows/component-build.yml
@@ -54,6 +54,28 @@ on:
         type: boolean
         default: true
         description: 'Enable registry-backed BuildKit cache (cache-from/cache-to) on the ECR repo. Set to false to opt out.'
+      persistent-builder:
+        required: false
+        type: boolean
+        default: false
+        description: |
+          Use a per-service named buildx builder (monta-<service-identifier>) and skip the
+          end-of-job teardown so the Dockerfile's cache mounts (e.g. /root/.gradle) survive
+          between jobs on the same self-hosted runner. Off by default to preserve existing
+          behavior for callers that haven't opted in. Operational note: enabling this lets
+          builder state accumulate on the runner over time; pair with periodic pruning if
+          your service builds frequently.
+      buildkit-cache-mode:
+        required: false
+        type: string
+        default: 'max'
+        description: |
+          BuildKit registry cache export mode. 'max' exports all intermediate layers and
+          Dockerfile cache-mount contents — best for cold-runner rehydration but produces
+          a large registry blob that can be slow to pull when ECR throughput is degraded.
+          'min' exports only final image layers, keeping the registry cache small; works
+          well combined with persistent-builder=true since the cache mounts then survive
+          locally on the runner.
     secrets:
       AWS_ACCOUNT_ID:
         required: true
@@ -162,15 +184,16 @@ jobs:
         uses: aws-actions/amazon-ecr-login@fa648b43de3d4d023bcb3f89ed6940096949c419 # v2
       # Required when enable-buildkit-cache=true: registry cache export needs the
       # docker-container buildx driver (the default docker driver does not support cache-to).
-      # name + cleanup: false keep the builder container alive between jobs on the same
-      # self-hosted runner, so the Dockerfile's /root/.gradle cache mount survives locally
-      # and the registry cache only needs to bootstrap cold runners.
+      # When persistent-builder=true: use a per-service stable builder name and skip cleanup
+      # so the Dockerfile's cache mounts (e.g. /root/.gradle) survive between jobs on the
+      # same self-hosted runner. Per-service naming avoids cross-service cache mount
+      # contention and limits the blast radius if a builder gets into a bad state.
       - name: Set up Docker Buildx
         if: ${{ inputs.enable-buildkit-cache }}
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
         with:
-          name: monta-builder
-          cleanup: false
+          name: ${{ inputs.persistent-builder && format('monta-{0}', inputs.service-identifier) || '' }}
+          cleanup: ${{ !inputs.persistent-builder }}
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6
@@ -197,12 +220,10 @@ jobs:
           sbom: false
           # Registry-backed BuildKit cache, scoped per-arch to keep amd64/arm64 caches separate.
           # Cache lives in the same ECR repo as the image under a dedicated tag, so existing
-          # ecr-put-image IAM permissions cover it. mode=min exports only the final image
-          # layers — not Dockerfile cache-mount contents — keeping the registry cache small
-          # so cold-runner bootstrap stays fast even when ECR pull throughput is degraded.
-          # The Gradle dep cache lives in the persistent local builder (see setup-buildx step).
+          # ecr-put-image IAM permissions cover it. Export mode is controlled by the
+          # buildkit-cache-mode input (default 'max' for back-compat).
           cache-from: ${{ inputs.enable-buildkit-cache && format('type=registry,ref={0}/{1}:buildcache-{2}', steps.login-ecr.outputs.registry, inputs.ecr-repository-name || format('{0}-{1}', inputs.service-identifier, inputs.stage), matrix.arch) || '' }}
-          cache-to: ${{ inputs.enable-buildkit-cache && format('type=registry,ref={0}/{1}:buildcache-{2},mode=min,image-manifest=true,oci-mediatypes=true', steps.login-ecr.outputs.registry, inputs.ecr-repository-name || format('{0}-{1}', inputs.service-identifier, inputs.stage), matrix.arch) || '' }}
+          cache-to: ${{ inputs.enable-buildkit-cache && format('type=registry,ref={0}/{1}:buildcache-{2},mode={3},image-manifest=true,oci-mediatypes=true', steps.login-ecr.outputs.registry, inputs.ecr-repository-name || format('{0}-{1}', inputs.service-identifier, inputs.stage), matrix.arch, inputs.buildkit-cache-mode) || '' }}
           build-args: |
             ${{ inputs.additional-build-args }}
           labels: |

--- a/.github/workflows/component-build.yml
+++ b/.github/workflows/component-build.yml
@@ -162,9 +162,15 @@ jobs:
         uses: aws-actions/amazon-ecr-login@fa648b43de3d4d023bcb3f89ed6940096949c419 # v2
       # Required when enable-buildkit-cache=true: registry cache export needs the
       # docker-container buildx driver (the default docker driver does not support cache-to).
+      # name + cleanup: false keep the builder container alive between jobs on the same
+      # self-hosted runner, so the Dockerfile's /root/.gradle cache mount survives locally
+      # and the registry cache only needs to bootstrap cold runners.
       - name: Set up Docker Buildx
         if: ${{ inputs.enable-buildkit-cache }}
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
+        with:
+          name: monta-builder
+          cleanup: false
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6
@@ -191,10 +197,12 @@ jobs:
           sbom: false
           # Registry-backed BuildKit cache, scoped per-arch to keep amd64/arm64 caches separate.
           # Cache lives in the same ECR repo as the image under a dedicated tag, so existing
-          # ecr-put-image IAM permissions cover it. mode=max exports all intermediate layers
-          # (and cache mount contents on BuildKit ≥0.12) for maximum reuse on the next build.
+          # ecr-put-image IAM permissions cover it. mode=min exports only the final image
+          # layers — not Dockerfile cache-mount contents — keeping the registry cache small
+          # so cold-runner bootstrap stays fast even when ECR pull throughput is degraded.
+          # The Gradle dep cache lives in the persistent local builder (see setup-buildx step).
           cache-from: ${{ inputs.enable-buildkit-cache && format('type=registry,ref={0}/{1}:buildcache-{2}', steps.login-ecr.outputs.registry, inputs.ecr-repository-name || format('{0}-{1}', inputs.service-identifier, inputs.stage), matrix.arch) || '' }}
-          cache-to: ${{ inputs.enable-buildkit-cache && format('type=registry,ref={0}/{1}:buildcache-{2},mode=max,image-manifest=true,oci-mediatypes=true', steps.login-ecr.outputs.registry, inputs.ecr-repository-name || format('{0}-{1}', inputs.service-identifier, inputs.stage), matrix.arch) || '' }}
+          cache-to: ${{ inputs.enable-buildkit-cache && format('type=registry,ref={0}/{1}:buildcache-{2},mode=min,image-manifest=true,oci-mediatypes=true', steps.login-ecr.outputs.registry, inputs.ecr-repository-name || format('{0}-{1}', inputs.service-identifier, inputs.stage), matrix.arch) || '' }}
           build-args: |
             ${{ inputs.additional-build-args }}
           labels: |

--- a/.github/workflows/deploy-kotlin.yml
+++ b/.github/workflows/deploy-kotlin.yml
@@ -125,6 +125,21 @@ on:
         required: false
         type: string
         description: 'Git SHA to checkout and build from. Defaults to the triggering commit SHA.'
+      persistent-builder:
+        required: false
+        type: boolean
+        default: false
+        description: |
+          Use a per-service named buildx builder and skip the end-of-job teardown so the
+          Dockerfile's cache mounts survive between jobs on the same self-hosted runner.
+          Off by default to preserve existing behavior. See component-build.yml for details.
+      buildkit-cache-mode:
+        required: false
+        type: string
+        default: 'max'
+        description: |
+          BuildKit registry cache export mode ('max' or 'min'). Defaults to 'max' to preserve
+          existing behavior. See component-build.yml for details.
 
     secrets:
       GHL_USERNAME:
@@ -245,6 +260,8 @@ jobs:
       ecr-repository-name: ${{ inputs.ecr-repository-name }}
       slack-message-id: ${{ needs.initialize.outputs.slack-message-id }}
       git-sha: ${{ inputs.git-sha }}
+      persistent-builder: ${{ inputs.persistent-builder }}
+      buildkit-cache-mode: ${{ inputs.buildkit-cache-mode }}
     secrets:
       AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID }}
       SLACK_APP_TOKEN: ${{ secrets.SLACK_APP_TOKEN }}


### PR DESCRIPTION
## Summary

Adds two new optional inputs to `deploy-kotlin.yml` and `component-build.yml` so service repos can opt into BuildKit cache tuning that targets occasional slow deploys. Both defaults preserve today's behavior — a vanilla merge is a no-op for every existing caller.

## Background

`service-grid` deploys occasionally stall for 20–30 min during the Build step. Traced to the BuildKit registry cache (`buildcache-{arch}` ECR tag) being pulled at ~150 KB/s on some self-hosted runners. Evidence — same 161 MB cache layer (`sha256:71448d6e…`):

- Fast run [25909194655](https://github.com/monta-app/service-grid/actions/runs/25909194655): layer pulled in **4.7s**, total build 3m39s.
- Slow run [25743413133](https://github.com/monta-app/service-grid/actions/runs/25743413133): same layer pulled in **946.3s** (~170 KB/s), total build 28m18s.

The 161 MB layer is the Gradle `/root/.gradle` cache mount that `mode=max` exports to the registry. When ECR pull throughput collapses, that one layer dominates the entire build.

## Changes

### `persistent-builder` (boolean, default `false`)

When `true`, configures `docker/setup-buildx-action` with:

- `name: monta-<service-identifier>` — stable per-service builder name. Per-service naming (not a global name) avoids cross-service cache-mount contention and limits the blast radius if a builder enters a bad state.
- `cleanup: false` — skip the end-of-job teardown so the BuildKit container and its cache mounts (e.g. Dockerfile `--mount=type=cache,target=/root/.gradle`) survive between jobs on the same self-hosted runner. Subsequent jobs that land on that runner reuse the existing builder and warm cache.

Operational note: enabling this lets builder state accumulate on the runner over time. Services that build frequently should pair with periodic pruning (e.g. `docker buildx prune --builder monta-<svc> --keep-storage 10GB`).

### `buildkit-cache-mode` (string, default `'max'`)

Selects the `mode=...` value for the registry `cache-to` export. `max` (today's default) exports all intermediate layers including Dockerfile cache-mount contents — best for cold-runner rehydration but produces a large registry blob that's slow to pull when ECR throughput is degraded. `min` exports only final image layers, keeping the registry cache small; pairs well with `persistent-builder: true` since the cache mounts then survive locally on the runner anyway.

## Backwards compatibility

Both inputs default to today's behavior:

- `persistent-builder: false` → `setup-buildx-action` runs with empty `name` (action's default random name) and `cleanup: true` — identical to pre-PR semantics.
- `buildkit-cache-mode: 'max'` → identical registry cache export to pre-PR.

Existing callers (`service-energy`, `service-openadr`, etc.) see no change unless they explicitly opt in.

## Test plan

`service-grid` is opting into both flags on prod and staging to validate the combined effect before any other service adopts them:

- PR: monta-app/service-grid#1039 — points grid deploys at `@experiment/grid-cache-tuning` with `persistent-builder: true` + `buildkit-cache-mode: "min"`
- After this PR merges, grid will be updated to reference `@main` again while keeping the opt-in flags

Validation:

- [ ] Existing callers (any service that doesn't pass the new inputs) deploy with identical timing and behavior
- [ ] `service-grid` deploys with the flags enabled — measure Build step duration over ~10 deploys, compare floor/ceiling to pre-PR baseline
- [ ] On a runner that recently built grid, second deploy reuses the `monta-grid` builder (verify in logs: no `Creating a new builder instance`)
- [ ] `buildcache-{arch}` ECR tag size shrinks for grid (mode=min produces a much smaller registry cache)