### PR TITLE
fix(deploy-bump): scope git add to edited files, drop soft reset

### DIFF
--- a/.github/workflows/component-deploy-v2.yml
+++ b/.github/workflows/component-deploy-v2.yml
@@ -154,7 +154,11 @@ jobs:
           git config user.name "GitHub Action"
           git config user.email "action@github.com"
 
-          git add .
+          # Stage only the helm values file we edited. A repo-wide `git add .`
+          # would sweep any other working-tree changes (stale runner state,
+          # side effects from earlier steps) into a commit mislabelled as a
+          # docker-tag bump — see monta-app/monorepo-typescript@716f5f7e3.
+          git add "$HELM_VALUES_PATH/values.yaml"
           git commit -m "Bump docker tag for ${{ inputs.service-identifier }} on ${{ inputs.stage }} to ${{ inputs.image-tag }}"
 
           for attempt in $(seq 1 10); do
@@ -169,12 +173,16 @@ jobs:
               echo "Rebase clean, retrying push..."
             else
               echo "Rebase conflict, re-applying changes on top of latest main..."
+              # Hard-reset to the new origin/main and re-apply the seds from
+              # scratch. Previous logic used `git reset --soft` + `git add .`,
+              # which kept the old tree in the index and produced commits that
+              # silently reverted unrelated changes between bases.
               git rebase --abort
-              git reset --soft origin/main
+              git reset --hard origin/main
               sed -i "s/tag: .*/tag: ${{ inputs.image-tag }}/" "$HELM_VALUES_PATH/values.yaml"
               sed -i "s/revision: .*/revision: \"${GITHUB_SHA::8}\"/" "$HELM_VALUES_PATH/values.yaml"
               sed -i "s/build: .*/build: ${{ github.run_number }}/" "$HELM_VALUES_PATH/values.yaml"
-              git add .
+              git add "$HELM_VALUES_PATH/values.yaml"
               git commit -m "Bump docker tag for ${{ inputs.service-identifier }} on ${{ inputs.stage }} to ${{ inputs.image-tag }}"
             fi
             sleep 2

--- a/.github/workflows/component-deploy-v2.yml
+++ b/.github/workflows/component-deploy-v2.yml
@@ -150,16 +150,15 @@ jobs:
         working-directory: ./service-repo
         env:
           HELM_VALUES_PATH: ${{ inputs.helm-values-path || format('helm/{0}/{1}/app', inputs.service-identifier, inputs.stage) }}
+          COMMIT_MSG: "Bump docker tag for ${{ inputs.service-identifier }} on ${{ inputs.stage }} to ${{ inputs.image-tag }}"
         run: |
           git config user.name "GitHub Action"
           git config user.email "action@github.com"
 
-          # Stage only the helm values file we edited. A repo-wide `git add .`
-          # would sweep any other working-tree changes (stale runner state,
-          # side effects from earlier steps) into a commit mislabelled as a
-          # docker-tag bump — see monta-app/monorepo-typescript@716f5f7e3.
+          # Stage only the file we sed-edited; a repo-wide `git add .` would
+          # sweep any other working-tree state into the bump commit.
           git add "$HELM_VALUES_PATH/values.yaml"
-          git commit -m "Bump docker tag for ${{ inputs.service-identifier }} on ${{ inputs.stage }} to ${{ inputs.image-tag }}"
+          git commit -m "$COMMIT_MSG"
 
           for attempt in $(seq 1 10); do
             echo "Push attempt $attempt..."
@@ -173,17 +172,16 @@ jobs:
               echo "Rebase clean, retrying push..."
             else
               echo "Rebase conflict, re-applying changes on top of latest main..."
-              # Hard-reset to the new origin/main and re-apply the seds from
-              # scratch. Previous logic used `git reset --soft` + `git add .`,
-              # which kept the old tree in the index and produced commits that
-              # silently reverted unrelated changes between bases.
+              # Hard-reset rather than soft: soft leaves the old tree in the
+              # index, and a subsequent broad `git add` would commit a diff
+              # that silently reverts changes between the old and new base.
               git rebase --abort
               git reset --hard origin/main
               sed -i "s/tag: .*/tag: ${{ inputs.image-tag }}/" "$HELM_VALUES_PATH/values.yaml"
               sed -i "s/revision: .*/revision: \"${GITHUB_SHA::8}\"/" "$HELM_VALUES_PATH/values.yaml"
               sed -i "s/build: .*/build: ${{ github.run_number }}/" "$HELM_VALUES_PATH/values.yaml"
               git add "$HELM_VALUES_PATH/values.yaml"
-              git commit -m "Bump docker tag for ${{ inputs.service-identifier }} on ${{ inputs.stage }} to ${{ inputs.image-tag }}"
+              git commit -m "$COMMIT_MSG"
             fi
             sleep 2
           done

--- a/.github/workflows/component-deploy.yml
+++ b/.github/workflows/component-deploy.yml
@@ -144,12 +144,16 @@ jobs:
         env:
           APP_PATH: apps/${{ inputs.service-identifier }}/${{ inputs.stage }}/app
           CLUSTER_PATH: apps/${{ inputs.service-identifier }}/${{ inputs.stage }}/cluster
+          COMMIT_MSG: "Bump docker tag for ${{ inputs.service-identifier }} on ${{ inputs.stage }} to ${{ inputs.image-tag }}"
         run: |
           git config user.name "GitHub Action"
           git config user.email "action@github.com"
 
-          git add .
-          git commit -m "Bump docker tag for ${{ inputs.service-identifier }} on ${{ inputs.stage }} to ${{ inputs.image-tag }}"
+          # Stage only the two files the earlier steps edited; a repo-wide
+          # `git add .` would sweep any other working-tree state into the
+          # bump commit.
+          git add "$APP_PATH/values.yaml" "$CLUSTER_PATH/config.yaml"
+          git commit -m "$COMMIT_MSG"
 
           for attempt in $(seq 1 10); do
             echo "Push attempt $attempt..."
@@ -163,15 +167,18 @@ jobs:
               echo "Rebase clean, retrying push..."
             else
               echo "Rebase conflict, re-applying changes on top of latest main..."
+              # Hard-reset rather than soft: soft leaves the old tree in the
+              # index, and a subsequent broad `git add` would commit a diff
+              # that silently reverts changes between the old and new base.
               git rebase --abort
-              git reset --soft origin/main
+              git reset --hard origin/main
               sed -i "s/tag: .*/tag: ${{ inputs.image-tag }}/" "$APP_PATH/values.yaml"
               sed -i "s/revision: .*/revision: \"${GITHUB_SHA::8}\"/" "$APP_PATH/values.yaml"
               sed -i "s/build: .*/build: ${{ github.run_number }}/" "$APP_PATH/values.yaml"
               previousHash=$(yq e .currentHash "$CLUSTER_PATH/config.yaml") yq e '.previousHash = strenv(previousHash)' -i "$CLUSTER_PATH/config.yaml"
               currentHash=${GITHUB_SHA::8} yq e '.currentHash = strenv(currentHash)' -i "$CLUSTER_PATH/config.yaml"
-              git add .
-              git commit -m "Bump docker tag for ${{ inputs.service-identifier }} on ${{ inputs.stage }} to ${{ inputs.image-tag }}"
+              git add "$APP_PATH/values.yaml" "$CLUSTER_PATH/config.yaml"
+              git commit -m "$COMMIT_MSG"
             fi
             sleep 2
           done


### PR DESCRIPTION
## Summary

The `Commit and push with automatic retry` step in both `component-deploy.yml` (V1) and `component-deploy-v2.yml` had two defects that let unrelated working-tree state land on a target repo's `main`, branded as a docker-tag bump.

### Defect 1 — repo-wide `git add .`

`git add .` from the repo root stages every dirty file on the runner. The sed step only edits one or two specific files, but the add scoops up everything: stale state on a self-hosted runner, side effects from earlier steps, anything left over in the workspace. The commit message says "Bump docker tag for X" but the commit can contain arbitrary diffs.

### Defect 2 — rebase-conflict recovery does a soft reset + `git add .`

When the retry loop's `git rebase origin/main` conflicts, the recovery path did:

```bash
git rebase --abort
git reset --soft origin/main
# re-apply edits
git add .
git commit -m "Bump docker tag …"
```

`git reset --soft` moves `HEAD` to the new base but leaves the **index** pointing at the old tree. The subsequent `git add .` reads the working tree (still at the old base + our edit) and stages it. The resulting commit's diff vs the new base is:

> `diff(new base → old tree) + the edits`

i.e. it silently reverts every change that landed between the old and new base.

### Fix

Applied to both `component-deploy.yml` (V1) and `component-deploy-v2.yml`:

- Replace `git add .` with an explicit add of the files the earlier steps edit:
  - V1: `git add "$APP_PATH/values.yaml" "$CLUSTER_PATH/config.yaml"`
  - V2: `git add "$HELM_VALUES_PATH/values.yaml"`
- Replace `git reset --soft origin/main` with `git reset --hard origin/main`. We re-apply the edits from scratch anyway, so a hard reset is what was meant; it also wipes any leftover state from the failed rebase.
- Hoist the duplicated commit message into a `COMMIT_MSG` env var so the two call sites can't drift.

## Why both files

V1 (`component-deploy.yml`) is consumed by `deploy-kotlin.yml`, `deploy-python.yml`, and `deploy-generic.yml`. That covers all the Monta Kotlin services (server, service-api-gateways, service-core-api, service-search, service-feature, service-wallet, service-identity, etc.) and Python services. V2 covers the monorepo-typescript apps. Both had the identical bug.

## Incident

[`monta-app/monorepo-typescript@716f5f7e3`](https://github.com/monta-app/monorepo-typescript/commit/716f5f7e3bcf61aba0f19a87ad0e0e142247bf6c) — a `Bump docker tag for react-storybook on staging` commit also contained two single-character TS edits in `apps/hub/src/domain/dashboard/feature/control-tower/…`, breaking `apps/hub` typecheck on `main`. TS revert: [`monta-app/monorepo-typescript#2990`](https://github.com/monta-app/monorepo-typescript/pull/2990).

Audited all 176 `GitHub Action`-authored commits on `monorepo-typescript`'s `main` since 2025-09 — that's the only one with non-helm files. This fix prevents recurrence regardless of how the runner's working tree gets dirtied.

## Test plan

- [x] Diff inspected — only touches the two bump steps
- [ ] V1 workflow runs on next Kotlin/Python deploy without regression
- [ ] V2 workflow runs on next monorepo-typescript deploy without regression
- [ ] No follow-up corrupted-bump commits appear on consumer repos / kube-manifests