### PR TITLE
chore: migrate Kotlin shared Sonar workflows to self-hosted SonarQube [NOJIRA]

### DIFF
--- a/.github/workflows/pull-request-kotlin.yml
+++ b/.github/workflows/pull-request-kotlin.yml
@@ -46,6 +46,9 @@ on:
         default: false
         description: 'Skip PR title check'
     secrets:
+      TAILSCALE_AUTHKEY:
+        required: true
+        description: "Authentication token used for logging into Tailscale"
       GHL_USERNAME:
         required: true
         description: "Github Username (Gradle plugin)"
@@ -54,7 +57,7 @@ on:
         description: "Github Password (Gradle plugin)"
       SONAR_TOKEN:
         required: true
-        description: "SonarCloud token"
+        description: "SonarQube token"
 jobs:
   setup:
     name: Setup
@@ -129,7 +132,16 @@ jobs:
             /home/runner/.gradle/daemon/**/daemon-*.out.log
           retention-days: 2
           overwrite: true
-      - name: Upload results to SonarCloud
+      # The self-hosted SonarQube lives behind the Monta VPN, so the runner
+      # needs to join the tailnet before the scan step can reach it.
+      - name: Tailscale
+        if: ${{ !inputs.skip-sonar }}
+        uses: tailscale/github-action@6cae46e2d796f265265cfcf628b72a32b4d7cade # v3.3.0
+        with:
+          authkey: ${{ secrets.TAILSCALE_AUTHKEY }}
+          hostname: "github-${{ github.run_id }}"
+          args: "--login-server https://headscale.monta.com --accept-routes"
+      - name: Upload results to SonarQube
         if: ${{ !inputs.skip-sonar }}
         env:
           GHL_USERNAME: ${{ secrets.GHL_USERNAME }}

--- a/.github/workflows/pull-request-kotlin.yml
+++ b/.github/workflows/pull-request-kotlin.yml
@@ -47,8 +47,8 @@ on:
         description: 'Skip PR title check'
     secrets:
       TAILSCALE_AUTHKEY:
-        required: true
-        description: "Authentication token used for logging into Tailscale"
+        required: false
+        description: "Tailscale auth key. When set, the runner joins the tailnet so it can reach the self-hosted SonarQube. Leave unset to keep scanning SonarCloud."
       GHL_USERNAME:
         required: true
         description: "Github Username (Gradle plugin)"
@@ -80,6 +80,8 @@ jobs:
     needs: setup
     runs-on: ${{ needs.setup.outputs.runner-name }}
     timeout-minutes: ${{ inputs.test-timeout-minutes }}
+    env:
+      TAILSCALE_AUTHKEY: ${{ secrets.TAILSCALE_AUTHKEY }}
     steps:
       # Checkout
       - name: Checkout
@@ -133,12 +135,13 @@ jobs:
           retention-days: 2
           overwrite: true
       # The self-hosted SonarQube lives behind the Monta VPN, so the runner
-      # needs to join the tailnet before the scan step can reach it.
+      # needs to join the tailnet before the scan step can reach it. Skipped
+      # automatically for repos still on SonarCloud (no TAILSCALE_AUTHKEY passed).
       - name: Tailscale
-        if: ${{ !inputs.skip-sonar }}
+        if: ${{ !inputs.skip-sonar && env.TAILSCALE_AUTHKEY != '' }}
         uses: tailscale/github-action@6cae46e2d796f265265cfcf628b72a32b4d7cade # v3.3.0
         with:
-          authkey: ${{ secrets.TAILSCALE_AUTHKEY }}
+          authkey: ${{ env.TAILSCALE_AUTHKEY }}
           hostname: "github-${{ github.run_id }}"
           args: "--login-server https://headscale.monta.com --accept-routes"
       - name: Upload results to SonarQube

--- a/.github/workflows/sonar-cloud.yml
+++ b/.github/workflows/sonar-cloud.yml
@@ -1,4 +1,4 @@
-name: Sonar Cloud Analysis
+name: SonarQube Analysis
 on:
   workflow_call:
     inputs:
@@ -26,6 +26,9 @@ on:
         default: "--no-daemon --parallel"
         description: 'Additional Gradle arguments'
     secrets:
+      TAILSCALE_AUTHKEY:
+        required: true
+        description: "Authentication token used for logging into Tailscale"
       GHL_USERNAME:
         required: true
         description: "Github Username (Gradle plugin)"
@@ -49,7 +52,7 @@ jobs:
           runner-size: ${{ inputs.runner-size }}
           architecture: ${{ inputs.architecture }}
   sonar-cloud:
-    name: Sonar Cloud Analysis
+    name: SonarQube Analysis
     needs: setup
     runs-on: ${{ needs.setup.outputs.runner-name }}
     timeout-minutes: 30
@@ -64,12 +67,20 @@ jobs:
           distribution: corretto
           java-version: ${{ inputs.java-version }}
           cache: 'gradle'
-      - name: Cache SonarCloud packages
+      - name: Cache SonarQube packages
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: ~/.sonar/cache
           key: ${{ runner.os }}-sonar
           restore-keys: ${{ runner.os }}-sonar
+      # The self-hosted SonarQube lives behind the Monta VPN, so the runner
+      # needs to join the tailnet before the scan step can reach it.
+      - name: Tailscale
+        uses: tailscale/github-action@6cae46e2d796f265265cfcf628b72a32b4d7cade # v3.3.0
+        with:
+          authkey: ${{ secrets.TAILSCALE_AUTHKEY }}
+          hostname: "github-${{ github.run_id }}"
+          args: "--login-server https://headscale.monta.com --accept-routes"
       - name: Build and analyze
         env:
           GHL_USERNAME: ${{ secrets.GHL_USERNAME }}

--- a/.github/workflows/sonar-cloud.yml
+++ b/.github/workflows/sonar-cloud.yml
@@ -27,8 +27,8 @@ on:
         description: 'Additional Gradle arguments'
     secrets:
       TAILSCALE_AUTHKEY:
-        required: true
-        description: "Authentication token used for logging into Tailscale"
+        required: false
+        description: "Tailscale auth key. When set, the runner joins the tailnet so it can reach the self-hosted SonarQube. Leave unset to keep scanning SonarCloud."
       GHL_USERNAME:
         required: true
         description: "Github Username (Gradle plugin)"
@@ -56,6 +56,8 @@ jobs:
     needs: setup
     runs-on: ${{ needs.setup.outputs.runner-name }}
     timeout-minutes: 30
+    env:
+      TAILSCALE_AUTHKEY: ${{ secrets.TAILSCALE_AUTHKEY }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
@@ -74,11 +76,13 @@ jobs:
           key: ${{ runner.os }}-sonar
           restore-keys: ${{ runner.os }}-sonar
       # The self-hosted SonarQube lives behind the Monta VPN, so the runner
-      # needs to join the tailnet before the scan step can reach it.
+      # needs to join the tailnet before the scan step can reach it. Skipped
+      # automatically for repos still on SonarCloud (no TAILSCALE_AUTHKEY passed).
       - name: Tailscale
+        if: ${{ env.TAILSCALE_AUTHKEY != '' }}
         uses: tailscale/github-action@6cae46e2d796f265265cfcf628b72a32b4d7cade # v3.3.0
         with:
-          authkey: ${{ secrets.TAILSCALE_AUTHKEY }}
+          authkey: ${{ env.TAILSCALE_AUTHKEY }}
           hostname: "github-${{ github.run_id }}"
           args: "--login-server https://headscale.monta.com --accept-routes"
       - name: Build and analyze


### PR DESCRIPTION
## Why
Migrate the two **reusable Kotlin Sonar workflows** to the self-hosted **SonarQube** at `https://sonarqube.vpn.internal.monta.app` (full migration — `#project-migrate-to-sonarqube`).

## Changes
- **`sonar-cloud.yml`** + **`pull-request-kotlin.yml`**: add a **Tailscale** step before the gradle `sonar` step so self-hosted ARC runners can reach the VPN-internal SonarQube (same pattern as `server#23360`).
- `TAILSCALE_AUTHKEY` is an **optional** secret, and the Tailscale step is **guarded** (`if: env.TAILSCALE_AUTHKEY != ''`).
- Rename display strings `SonarCloud` → `SonarQube`.

## Backward compatible — no flag day
Because the workflows are pinned `@main`, a required secret would break every caller the instant this merges. Instead this is **opt-in per repo**:
- **Not yet migrated** (no `TAILSCALE_AUTHKEY`, `build.gradle.kts` still on `sonarcloud.io`) → Tailscale step skips, scan keeps hitting **SonarCloud**. ✅ unchanged
- **Migrated** (caller passes `TAILSCALE_AUTHKEY` + maps `SONAR_TOKEN: secrets.SONARQUBE_TOKEN`, `build.gradle.kts` → self-hosted) → runner joins the tailnet, scans **self-hosted**.

So this PR is safe to merge first, and each Kotlin service then migrates independently in its own PR (build.gradle.kts host + caller secret mapping). No coordinated big-bang merge required.

## Reference
Pattern: `monta-app/server#23360`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)