### PR TITLE
feat(pr-digest): reusable workflow for AI-curated PR Slack digest

### DIFF
--- a/.github/workflows/pr-digest.yml
+++ b/.github/workflows/pr-digest.yml
@@ -39,9 +39,9 @@ on:
         type: boolean
         default: true
       model:
-        description: "Anthropic model identifier for AI curation (e.g. claude-sonnet-4-7, claude-haiku-4-5)."
+        description: "Anthropic model identifier for AI curation (e.g. claude-sonnet-4-6, claude-haiku-4-5). Must be a valid API ID from https://docs.anthropic.com/en/docs/about-claude/models/overview."
         type: string
-        default: "claude-sonnet-4-7"
+        default: "claude-sonnet-4-6"
       post-thread-breakdown:
         description: "Reply in-thread with the full per-area PR breakdown."
         type: boolean
@@ -69,7 +69,7 @@ permissions:
 jobs:
   digest:
     name: Build and post PR digest
-    runs-on: ubuntu-latest
+    runs-on: linux-arm64
     timeout-minutes: 10
     env:
       GH_TOKEN: ${{ github.token }}
@@ -238,6 +238,8 @@ jobs:
           AI_AVAILABLE="false"
           if [[ -s /tmp/ai.json ]]; then
             AI_AVAILABLE="true"
+          else
+            echo '{"headline":"","focus":[]}' > /tmp/ai.json
           fi
           jq -n \
             --arg channel "$SLACK_CHANNEL_ID" \
@@ -270,7 +272,7 @@ jobs:
             def mergeIcon(m):
               if m == "CONFLICTING" then " · ❌ conflicts"
               else "" end;
-            def escapeSlack: gsub("[<>&]"; " ");
+            def escapeSlack: gsub("&"; "&amp;") | gsub("<"; "&lt;") | gsub(">"; "&gt;");
             def prLine(pr):
               "\(severity(pr.idleDays)) *<\(pr.url)|#\(pr.n // pr.number) \(pr.title | escapeSlack)>*\n" +
               "_by *@\(pr.author.login)* · idle *\(pr.idleDays)d* · \(reviewIcon(pr.reviewDecision)) \(reviewLabel(pr.reviewDecision))\(mergeIcon(pr.mergeable))_";
@@ -393,7 +395,7 @@ jobs:
               if r == "APPROVED" then "✅"
               elif r == "CHANGES_REQUESTED" then "🛑"
               else "👀" end;
-            def escapeSlack: gsub("[<>&]"; " ");
+            def escapeSlack: gsub("&"; "&amp;") | gsub("<"; "&lt;") | gsub(">"; "&gt;");
             def prLine(pr):
               "\(severity(pr.idleDays)) <\(pr.url)|#\(pr.n // pr.number)> \(pr.title | escapeSlack) · @\(pr.author.login) · \(pr.idleDays)d · \(reviewIcon(pr.reviewDecision))";
 

--- a/.github/workflows/pr-digest.yml
+++ b/.github/workflows/pr-digest.yml
@@ -142,9 +142,11 @@ jobs:
           TOTAL=$(jq 'length' /tmp/enriched.json)
           STALE=$(jq '[.[] | select(.bucket == "stale" or .bucket == "critical")] | length' /tmp/enriched.json)
           CRITICAL=$(jq '[.[] | select(.bucket == "critical")] | length' /tmp/enriched.json)
-          echo "TOTAL_PRS=$TOTAL" >> "$GITHUB_ENV"
-          echo "STALE_PRS=$STALE" >> "$GITHUB_ENV"
-          echo "CRITICAL_PRS=$CRITICAL" >> "$GITHUB_ENV"
+          {
+            echo "TOTAL_PRS=$TOTAL"
+            echo "STALE_PRS=$STALE"
+            echo "CRITICAL_PRS=$CRITICAL"
+          } >> "$GITHUB_ENV"
           echo "Open: $TOTAL · Stale: $STALE · Critical: $CRITICAL"
 
       - name: AI curation

--- a/.github/workflows/pr-digest.yml
+++ b/.github/workflows/pr-digest.yml
@@ -1,0 +1,431 @@
+name: PR Digest
+
+# Reusable workflow that posts a Slack digest of open pull requests in the
+# calling repository. Designed for high-volume repos (100+ open PRs): the
+# message is AI-curated by default so the channel sees a focused triage view
+# instead of a flat list of every open PR.
+#
+# See docs/workflow-guide.md → "PR Digest" for usage.
+
+on:
+  workflow_call:
+    inputs:
+      slack-channel-id:
+        description: "Slack channel ID to post the digest to (e.g. C0ALEGFRPU1)."
+        type: string
+        required: true
+      stale-threshold-days:
+        description: "Days of inactivity before a PR counts as 'stale' in the headline stats."
+        type: number
+        default: 2
+      critical-threshold-days:
+        description: "Days of inactivity for a PR to be surfaced individually as 'critical' (about to be auto-closed)."
+        type: number
+        default: 7
+      max-prs-to-surface:
+        description: "Max PRs to render by name in the 'Today's focus' section. The rest are summarised by area in the thread reply."
+        type: number
+        default: 5
+      include-drafts:
+        description: "Include draft PRs in the digest."
+        type: boolean
+        default: false
+      exclude-authors:
+        description: "Comma-separated list of GitHub logins to exclude (e.g. dependabot[bot])."
+        type: string
+        default: "dependabot[bot],renovate[bot]"
+      use-ai-curation:
+        description: "Use Claude to pick the focus PRs and write the headline. Falls back to deterministic 'oldest-first' if the AI call fails."
+        type: boolean
+        default: true
+      model:
+        description: "Anthropic model identifier for AI curation (e.g. claude-sonnet-4-7, claude-haiku-4-5)."
+        type: string
+        default: "claude-sonnet-4-7"
+      post-thread-breakdown:
+        description: "Reply in-thread with the full per-area PR breakdown."
+        type: boolean
+        default: true
+      title:
+        description: "Header text for the Slack message. Defaults to the repository name."
+        type: string
+        default: ""
+      empty-state:
+        description: "What to do when no PRs are stale: 'silent' (post nothing) or 'celebrate' (post a 🎉 message)."
+        type: string
+        default: "silent"
+    secrets:
+      SLACK_APP_TOKEN:
+        description: "Slack bot token with chat:write scope. Must be a member of the target channel."
+        required: true
+      ANTHROPIC_API_KEY:
+        description: "Anthropic API key. Only required when use-ai-curation is true."
+        required: false
+
+permissions:
+  pull-requests: read
+  contents: read
+
+jobs:
+  digest:
+    name: Build and post PR digest
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      GH_TOKEN: ${{ github.token }}
+      REPO: ${{ github.repository }}
+      SLACK_BOT_TOKEN: ${{ secrets.SLACK_APP_TOKEN }}
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+      SLACK_CHANNEL_ID: ${{ inputs.slack-channel-id }}
+      STALE_THRESHOLD_DAYS: ${{ inputs.stale-threshold-days }}
+      CRITICAL_THRESHOLD_DAYS: ${{ inputs.critical-threshold-days }}
+      MAX_PRS_TO_SURFACE: ${{ inputs.max-prs-to-surface }}
+      INCLUDE_DRAFTS: ${{ inputs.include-drafts }}
+      EXCLUDE_AUTHORS: ${{ inputs.exclude-authors }}
+      USE_AI_CURATION: ${{ inputs.use-ai-curation }}
+      ANTHROPIC_MODEL: ${{ inputs.model }}
+      POST_THREAD_BREAKDOWN: ${{ inputs.post-thread-breakdown }}
+      TITLE_OVERRIDE: ${{ inputs.title }}
+      EMPTY_STATE: ${{ inputs.empty-state }}
+      WORKFLOW_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+      PRS_URL: ${{ github.server_url }}/${{ github.repository }}/pulls
+
+    steps:
+      - name: Fetch open PRs
+        run: |
+          set -euo pipefail
+          gh pr list \
+            --repo "$REPO" \
+            --state open \
+            --limit 500 \
+            --json number,title,author,url,isDraft,updatedAt,createdAt,labels,reviewDecision,headRefName,mergeable,additions,deletions \
+            > /tmp/prs.json
+          echo "Fetched $(jq 'length' /tmp/prs.json) open PRs."
+
+      - name: Filter and enrich
+        run: |
+          set -euo pipefail
+          jq \
+            --argjson stale "$STALE_THRESHOLD_DAYS" \
+            --argjson critical "$CRITICAL_THRESHOLD_DAYS" \
+            --arg includeDrafts "$INCLUDE_DRAFTS" \
+            --arg excludeCsv "$EXCLUDE_AUTHORS" \
+            '
+            ($excludeCsv | split(",") | map(gsub("^\\s+|\\s+$"; ""))) as $excluded
+            | ($includeDrafts == "true") as $includeDrafts
+            | [ .[]
+                | (.updatedAt | fromdateiso8601) as $epoch
+                | . + {
+                    updatedEpoch: $epoch,
+                    idleDays: ((now - $epoch) / 86400 | floor),
+                    primaryLabel: (
+                      (.labels // [])
+                      | map(.name)
+                      | map(select(test("^(hub|api-gateway|control-v2|portals|installers|control|ocpp-toolkit|storybook|dependencies|security)$")))
+                      | (.[0] // "other")
+                    )
+                  }
+                | . + {
+                    bucket: (
+                      if .idleDays >= $critical then "critical"
+                      elif .idleDays >= $stale then "stale"
+                      else "fresh" end
+                    )
+                  }
+                | select(
+                    ($includeDrafts or (.isDraft | not))
+                    and (.author.login as $login | $excluded | index($login) | not)
+                  )
+              ]
+            | sort_by(.updatedEpoch)
+            ' /tmp/prs.json > /tmp/enriched.json
+          TOTAL=$(jq 'length' /tmp/enriched.json)
+          STALE=$(jq '[.[] | select(.bucket == "stale" or .bucket == "critical")] | length' /tmp/enriched.json)
+          CRITICAL=$(jq '[.[] | select(.bucket == "critical")] | length' /tmp/enriched.json)
+          echo "TOTAL_PRS=$TOTAL" >> "$GITHUB_ENV"
+          echo "STALE_PRS=$STALE" >> "$GITHUB_ENV"
+          echo "CRITICAL_PRS=$CRITICAL" >> "$GITHUB_ENV"
+          echo "Open: $TOTAL · Stale: $STALE · Critical: $CRITICAL"
+
+      - name: AI curation
+        id: ai
+        if: ${{ inputs.use-ai-curation && env.STALE_PRS != '0' && env.ANTHROPIC_API_KEY != '' }}
+        continue-on-error: true
+        timeout-minutes: 2
+        run: |
+          set -euo pipefail
+          COMPACT=$(jq '[ .[] | {
+            n: .number,
+            title: .title,
+            author: .author.login,
+            idle: .idleDays,
+            review: .reviewDecision,
+            labels: (.labels // []) | map(.name),
+            area: .primaryLabel,
+            mergeable: .mergeable,
+            additions: .additions,
+            deletions: .deletions,
+            draft: .isDraft
+          } ]' /tmp/enriched.json)
+          PROMPT=$(jq -n \
+            --arg repo "$REPO" \
+            --argjson stale "$STALE_THRESHOLD_DAYS" \
+            --argjson critical "$CRITICAL_THRESHOLD_DAYS" \
+            --argjson maxFocus "$MAX_PRS_TO_SURFACE" \
+            --arg data "$COMPACT" \
+            '
+            "You are writing the curated section of a daily Slack PR digest for the GitHub repository \($repo).\n\nInput: a JSON array of open pull requests. Fields:\n- n: PR number\n- title, author, idle (days), review (APPROVED|CHANGES_REQUESTED|REVIEW_REQUIRED|null)\n- labels, area (one of hub/api-gateway/control-v2/portals/installers/control/ocpp-toolkit/storybook/dependencies/security/other)\n- mergeable (MERGEABLE|CONFLICTING|UNKNOWN), additions, deletions, draft\n\nStale threshold: \($stale)d. Critical (about to be auto-closed): \($critical)d.\n\nReturn STRICT JSON only, no prose, no markdown fences. Schema:\n{\n  \"headline\": \"<1-2 sentences, 280 chars max. A colleague-tone standup-style nudge for the channel. Mention specific @authors and #numbers where they add value. Do NOT restate counts — the next block already shows them.>\",\n  \"focus\": [ { \"pr_number\": <int>, \"reason\": \"<short, 80 chars max, no PR title — explain WHY this one matters today>\" } ]\n}\n\nRules for `focus`:\n- Up to \($maxFocus) entries.\n- Prioritise: approved-but-unmerged > conflicts > critical-bucket (idle≥\($critical)d) > review-blocking patterns.\n- Skip if there is nothing genuinely focus-worthy (return empty array).\n- Each PR appears at most once.\n- Do not include bot-authored PRs (e.g. dependabot, renovate) unless they form a notable pattern.\n\nData:\n\($data)"
+            ')
+          REQUEST=$(jq -n \
+            --arg model "$ANTHROPIC_MODEL" \
+            --arg prompt "$PROMPT" \
+            '{
+              model: $model,
+              max_tokens: 1024,
+              messages: [{ role: "user", content: $prompt }]
+            }')
+          RESPONSE=$(curl -sS --max-time 60 https://api.anthropic.com/v1/messages \
+            -H "x-api-key: $ANTHROPIC_API_KEY" \
+            -H "anthropic-version: 2023-06-01" \
+            -H "content-type: application/json" \
+            --data "$REQUEST")
+          if [[ -z "$RESPONSE" ]] || echo "$RESPONSE" | jq -e '.error' > /dev/null 2>&1; then
+            echo "::warning::Anthropic API returned an error or empty response; falling back to deterministic curation."
+            echo "$RESPONSE" | jq . || echo "$RESPONSE"
+            exit 1
+          fi
+          TEXT=$(echo "$RESPONSE" | jq -r '.content[0].text // empty')
+          if [[ -z "$TEXT" ]]; then
+            echo "::warning::Anthropic returned no text content; falling back."
+            exit 1
+          fi
+          echo "$TEXT" | jq . > /tmp/ai.json
+          echo "AI curation generated:"
+          jq . /tmp/ai.json
+
+      - name: Build Slack message
+        id: build
+        run: |
+          set -euo pipefail
+          TITLE="${TITLE_OVERRIDE:-Open PRs in $REPO}"
+          if [[ "$STALE_PRS" -eq 0 ]]; then
+            if [[ "$EMPTY_STATE" == "silent" ]]; then
+              echo "✅ No stale PRs and empty-state=silent. Exiting cleanly."
+              echo "should-post=false" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            jq -n \
+              --arg channel "$SLACK_CHANNEL_ID" \
+              --arg title "$TITLE" \
+              --arg run_url "$WORKFLOW_RUN_URL" \
+              --arg prs_url "$PRS_URL" \
+              --argjson stale "$STALE_THRESHOLD_DAYS" \
+              --argjson total "$TOTAL_PRS" \
+              '{
+                channel: $channel,
+                text: "🎉 No stale PRs in \($title)",
+                blocks: [
+                  { type: "header", text: { type: "plain_text", text: "🎉 \($title): all clear", emoji: true } },
+                  { type: "context", elements: [{ type: "mrkdwn", text: "\($total) open PR(s), none idle ≥ *\($stale) days*. <\($prs_url)|All open PRs ↗> · <\($run_url)|Run ↗>" }] }
+                ]
+              }' > /tmp/main-payload.json
+            echo "should-post=true" >> "$GITHUB_OUTPUT"
+            echo "post-thread=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          AI_AVAILABLE="false"
+          if [[ -s /tmp/ai.json ]]; then
+            AI_AVAILABLE="true"
+          fi
+          jq -n \
+            --arg channel "$SLACK_CHANNEL_ID" \
+            --arg title "$TITLE" \
+            --arg run_url "$WORKFLOW_RUN_URL" \
+            --arg prs_url "$PRS_URL" \
+            --argjson total "$TOTAL_PRS" \
+            --argjson stale "$STALE_PRS" \
+            --argjson critical "$CRITICAL_PRS" \
+            --argjson staleDays "$STALE_THRESHOLD_DAYS" \
+            --argjson criticalDays "$CRITICAL_THRESHOLD_DAYS" \
+            --argjson maxFocus "$MAX_PRS_TO_SURFACE" \
+            --slurpfile prs /tmp/enriched.json \
+            --arg aiAvailable "$AI_AVAILABLE" \
+            --slurpfile aiSlurp /tmp/ai.json \
+            '
+            def severity(d):
+              if d >= 14 then "🚨"
+              elif d >= 8 then "🔴"
+              elif d >= 5 then "🟠"
+              else "🟡" end;
+            def reviewIcon(r):
+              if r == "APPROVED" then "✅"
+              elif r == "CHANGES_REQUESTED" then "🛑"
+              else "👀" end;
+            def reviewLabel(r):
+              if r == "APPROVED" then "approved"
+              elif r == "CHANGES_REQUESTED" then "changes requested"
+              else "needs review" end;
+            def mergeIcon(m):
+              if m == "CONFLICTING" then " · ❌ conflicts"
+              else "" end;
+            def escapeSlack: gsub("[<>&]"; " ");
+            def prLine(pr):
+              "\(severity(pr.idleDays)) *<\(pr.url)|#\(pr.n // pr.number) \(pr.title | escapeSlack)>*\n" +
+              "_by *@\(pr.author.login)* · idle *\(pr.idleDays)d* · \(reviewIcon(pr.reviewDecision)) \(reviewLabel(pr.reviewDecision))\(mergeIcon(pr.mergeable))_";
+
+            ($prs[0]) as $allPrs
+            | ($aiAvailable == "true") as $hasAi
+            | (if $hasAi then $aiSlurp[0] else { headline: null, focus: [] } end) as $ai
+            | ($ai.focus // []) as $aiFocus
+            | ([ $aiFocus[].pr_number ]) as $focusNumbers
+            | ([ $allPrs[] | select(.bucket == "critical") ]) as $criticalPrs
+            | ([ $allPrs[] | select(.bucket == "stale" or .bucket == "critical") ]) as $stalePrs
+            | (
+                if ($focusNumbers | length) > 0 then
+                  [ $aiFocus[]
+                    | . as $f
+                    | ($allPrs[] | select(.number == $f.pr_number)) as $pr
+                    | { pr: $pr, reason: $f.reason }
+                  ]
+                else
+                  [ $stalePrs[0:$maxFocus][] | { pr: ., reason: null } ]
+                end
+              ) as $focusItems
+            | ([
+                $stalePrs
+                | group_by(.primaryLabel)
+                | map({
+                    area: (.[0].primaryLabel),
+                    total: length,
+                    critical: ([ .[] | select(.bucket == "critical") ] | length),
+                    stale: ([ .[] | select(.bucket == "stale") ] | length)
+                  })
+                | sort_by(-.total)
+              ][0]) as $areaSummary
+            | {
+                channel: $channel,
+                text: "\($stale) stale PR(s) in \($title)",
+                blocks: (
+                  [
+                    { type: "header", text: { type: "plain_text", text: "🚦 \($title)", emoji: true } },
+                    { type: "context", elements: [{ type: "mrkdwn", text: "*\($total) open* · *\($stale) stale* (≥\($staleDays)d) · *\($critical) critical* (≥\($criticalDays)d)" }] }
+                  ]
+                  + (if ($ai.headline // "") | length > 0 then [
+                      { type: "section", text: { type: "mrkdwn", text: "🧠  \($ai.headline)" } }
+                    ] else [] end)
+                  + (if ($focusItems | length) > 0 then
+                      [ { type: "divider" },
+                        { type: "section", text: { type: "mrkdwn", text: "*Today'"'"'s focus*" } } ]
+                      + ($focusItems | map(
+                          { type: "section",
+                            text: {
+                              type: "mrkdwn",
+                              text: (prLine(.pr) + (if .reason then "\n>_\(.reason)_" else "" end))
+                            } }
+                        ))
+                    else [] end)
+                  + (if ($criticalPrs | length) > 0 and ($focusNumbers | length) == 0 then
+                      [ { type: "divider" },
+                        { type: "section", text: { type: "mrkdwn", text: "*🚨 Critical (≥\($criticalDays)d, about to auto-close)*" } } ]
+                      + ($criticalPrs[0:5] | map(
+                          { type: "section", text: { type: "mrkdwn", text: prLine(.) } }
+                        ))
+                    else [] end)
+                  + (if ($areaSummary | length) > 1 then
+                      [ { type: "divider" },
+                        { type: "section", text: { type: "mrkdwn", text: "*By area*" } },
+                        { type: "section",
+                          text: {
+                            type: "mrkdwn",
+                            text: ($areaSummary | map(
+                              "• `\(.area)` — \(.total) stale" +
+                              (if .critical > 0 then " (*\(.critical) critical*)" else "" end)
+                            ) | join("\n"))
+                          } } ]
+                    else [] end)
+                  + [
+                      { type: "divider" },
+                      { type: "context", elements: [{ type: "mrkdwn", text: "<\($prs_url)|All open PRs ↗> · <\($run_url)|Workflow run ↗>" }] }
+                    ]
+                )
+              }
+            ' > /tmp/main-payload.json
+          echo "should-post=true" >> "$GITHUB_OUTPUT"
+          echo "post-thread=true" >> "$GITHUB_OUTPUT"
+
+      - name: Post main message to Slack
+        if: steps.build.outputs.should-post == 'true'
+        id: post
+        run: |
+          set -euo pipefail
+          RESPONSE=$(curl -sS --max-time 30 -X POST https://slack.com/api/chat.postMessage \
+            -H "Authorization: Bearer $SLACK_BOT_TOKEN" \
+            -H "Content-Type: application/json; charset=utf-8" \
+            --data @/tmp/main-payload.json)
+          OK=$(echo "$RESPONSE" | jq -r '.ok')
+          if [[ "$OK" != "true" ]]; then
+            echo "::error::Slack API rejected the message:"
+            echo "$RESPONSE" | jq .
+            exit 1
+          fi
+          TS=$(echo "$RESPONSE" | jq -r '.ts')
+          echo "thread-ts=$TS" >> "$GITHUB_OUTPUT"
+          echo "✅ Posted main digest to $SLACK_CHANNEL_ID (ts=$TS)"
+
+      - name: Post thread breakdown
+        if: ${{ inputs.post-thread-breakdown && steps.build.outputs.post-thread == 'true' && steps.post.outputs.thread-ts != '' }}
+        run: |
+          set -euo pipefail
+          THREAD_TS="${{ steps.post.outputs.thread-ts }}"
+          jq -n \
+            --arg channel "$SLACK_CHANNEL_ID" \
+            --arg ts "$THREAD_TS" \
+            --slurpfile prs /tmp/enriched.json \
+            '
+            def severity(d):
+              if d >= 14 then "🚨"
+              elif d >= 8 then "🔴"
+              elif d >= 5 then "🟠"
+              else "🟡" end;
+            def reviewIcon(r):
+              if r == "APPROVED" then "✅"
+              elif r == "CHANGES_REQUESTED" then "🛑"
+              else "👀" end;
+            def escapeSlack: gsub("[<>&]"; " ");
+            def prLine(pr):
+              "\(severity(pr.idleDays)) <\(pr.url)|#\(pr.n // pr.number)> \(pr.title | escapeSlack) · @\(pr.author.login) · \(pr.idleDays)d · \(reviewIcon(pr.reviewDecision))";
+
+            ($prs[0]) as $allPrs
+            | ([ $allPrs[] | select(.bucket == "stale" or .bucket == "critical") ]
+                | group_by(.primaryLabel)
+                | map({ area: (.[0].primaryLabel), prs: . })
+                | sort_by(-(.prs | length))
+              ) as $byArea
+            | {
+                channel: $channel,
+                thread_ts: $ts,
+                blocks: (
+                  [ { type: "section", text: { type: "mrkdwn", text: "*Full breakdown — \(($allPrs | map(select(.bucket != "fresh")) | length)) stale PR(s) by area*" } } ]
+                  + ($byArea | map(
+                      [ { type: "divider" },
+                        { type: "section",
+                          text: {
+                            type: "mrkdwn",
+                            text: "*`\(.area)`* — \(.prs | length) stale\n" +
+                                  (.prs | map(prLine(.)) | join("\n"))
+                          } } ]
+                    ) | flatten)
+                )
+              }
+            ' > /tmp/thread-payload.json
+          RESPONSE=$(curl -sS --max-time 30 -X POST https://slack.com/api/chat.postMessage \
+            -H "Authorization: Bearer $SLACK_BOT_TOKEN" \
+            -H "Content-Type: application/json; charset=utf-8" \
+            --data @/tmp/thread-payload.json)
+          OK=$(echo "$RESPONSE" | jq -r '.ok')
+          if [[ "$OK" != "true" ]]; then
+            echo "::warning::Failed to post thread breakdown:"
+            echo "$RESPONSE" | jq .
+            exit 0
+          fi
+          echo "✅ Posted thread breakdown."

--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@ This repository contains several reusable workflows designed to streamline the C
 ### `semgrep-security-scan.yml`
 - **Purpose**: Runs Semgrep static analysis to detect security vulnerabilities, hardcoded secrets, and unsafe coding patterns. Designed primarily for pull requests (PR commenting, diff-aware scanning), but can be called from other event types via `workflow_call` with limited functionality.
 
+### `pr-digest.yml`
+- **Purpose**: Posts a daily Slack digest of open pull requests for the calling repository. AI-curates the message (focus PRs, headline, area summary) for high-volume repos, with a deterministic fallback. See [PR Digest in workflow-guide.md](./docs/workflow-guide.md#pr-digest).
+
 ### `deploy.yml`
 - **Purpose**: Manages deployments to various environments based on the branch being deployed.
 
@@ -271,6 +274,70 @@ jobs:
 - **Kotlin**: `p/kotlin`, `p/java`, `r/kotlin.lang.security`, `r/java.lang.security`
 - **PHP**: `p/php`, `r/php.lang.security`
 - **All**: `p/security-audit`, `p/secrets`, `p/github-actions`, `p/docker`
+
+### 6. **PR Digest (daily Slack notification of open PRs)**
+
+Post a daily Slack digest of the calling repo's open PRs. Designed for high-volume repos: AI-curates the message into a focused triage view ("today's focus", critical PRs, area summary) and posts the long-tail breakdown as a thread reply.
+
+**Prerequisites:**
+- A Slack channel ID (e.g. `C0ALEGFRPU1`) and the `SLACK_APP_TOKEN` bot is a member of that channel.
+- `ANTHROPIC_API_KEY` as a repo or org secret (only when `use-ai-curation: true`, which is the default).
+
+**Example (high-volume repo, 9 AM Europe/Copenhagen year-round):**
+```yaml
+name: PR digest
+
+on:
+  schedule:
+    - cron: "7 7 * * 1-5"  # 09:07 CEST
+    - cron: "7 8 * * 1-5"  # 09:07 CET
+  workflow_dispatch:
+
+jobs:
+  schedule-guard:
+    runs-on: ubuntu-latest
+    outputs:
+      proceed: ${{ steps.check.outputs.proceed }}
+    steps:
+      - id: check
+        run: |
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            echo "proceed=true" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+          LOCAL_HOUR=$(TZ=Europe/Copenhagen date +%H)
+          if [[ "$LOCAL_HOUR" == "09" ]]; then
+            echo "proceed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "proceed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  digest:
+    needs: schedule-guard
+    if: needs.schedule-guard.outputs.proceed == 'true'
+    uses: monta-app/github-workflows/.github/workflows/pr-digest.yml@main
+    with:
+      slack-channel-id: C0ALEGFRPU1
+      stale-threshold-days: 2
+      critical-threshold-days: 7
+      title: "my-repo — open PRs"
+    secrets: inherit
+```
+
+**Low-volume repo (flat list, no AI):**
+```yaml
+jobs:
+  digest:
+    uses: monta-app/github-workflows/.github/workflows/pr-digest.yml@main
+    with:
+      slack-channel-id: C0XXXXXXXXX
+      use-ai-curation: false
+      post-thread-breakdown: false
+      empty-state: celebrate
+    secrets:
+      SLACK_APP_TOKEN: ${{ secrets.SLACK_APP_TOKEN }}
+```
+
+Full input/secret reference: [PR Digest in workflow-guide.md](./docs/workflow-guide.md#pr-digest).
 
 ## Contributing ##
 

--- a/docs/workflow-guide.md
+++ b/docs/workflow-guide.md
@@ -20,6 +20,7 @@ This guide provides a comprehensive overview of all reusable GitHub workflows in
 14. [Rollback](#rollback)
 15. [SonarCloud Analysis](#sonarcloud-analysis)
 16. [Track Pending Release](#track-pending-release)
+17. [PR Digest](#pr-digest)
 
 ---
 
@@ -1200,3 +1201,116 @@ Most workflows require organization or repository secrets. Add these in your rep
    - Ensure tests generate coverage data
 
 For additional support, check the workflow logs in GitHub Actions or contact the platform team.
+
+---
+
+## PR Digest
+
+**File:** `pr-digest.yml`
+**Purpose:** Posts a daily Slack digest of open pull requests in the calling repository. Designed for high-volume repos (100+ open PRs): the message is AI-curated by default so the channel sees a focused triage view ("today's focus", critical PRs, area summary) instead of a flat list of every open PR. Falls back to deterministic oldest-first surfacing when AI is disabled or unavailable.
+
+### What it does:
+1. Fetches all open PRs in the calling repo via the GitHub CLI (no checkout needed).
+2. Filters out excluded authors (default: Dependabot, Renovate) and drafts (configurable).
+3. Buckets PRs as `fresh`, `stale` (≥ `stale-threshold-days`), or `critical` (≥ `critical-threshold-days`).
+4. **Optional:** sends a compact JSON of the data to the Anthropic API (Claude) and asks it to produce a 1–2 sentence headline plus up to N focus PRs with one-line "why this matters" notes.
+5. Builds a Slack Block Kit message with: header + counts, AI headline (if any), today's focus PRs, area summary, deep-link footer.
+6. **Optional:** posts a threaded follow-up with the full per-area PR breakdown.
+7. Posts via `chat.postMessage` using the existing `SLACK_APP_TOKEN`.
+
+### Inputs:
+| Input | Required | Default | Description |
+|-------|----------|---------|-------------|
+| `slack-channel-id` | **Yes** | - | Slack channel ID (e.g. `C0ALEGFRPU1`). The bot behind `SLACK_APP_TOKEN` must be a member. |
+| `stale-threshold-days` | No | `2` | Days of inactivity before a PR counts as "stale" in the headline stats. |
+| `critical-threshold-days` | No | `7` | Days of inactivity for a PR to be surfaced individually as "critical" (about to be auto-closed). |
+| `max-prs-to-surface` | No | `5` | Max PRs to render by name in the "Today's focus" section. |
+| `include-drafts` | No | `false` | Include draft PRs in the digest. |
+| `exclude-authors` | No | `"dependabot[bot],renovate[bot]"` | Comma-separated GitHub logins to exclude. |
+| `use-ai-curation` | No | `true` | Use Claude to pick focus PRs and write the headline. Falls back gracefully if the call fails. |
+| `model` | No | `"claude-sonnet-4-7"` | Anthropic model identifier. Use `claude-haiku-4-5` for ~10× cheaper, slightly less nuanced output. |
+| `post-thread-breakdown` | No | `true` | Reply in-thread with the full per-area PR breakdown. |
+| `title` | No | repo name | Header text for the Slack message. |
+| `empty-state` | No | `"silent"` | When no PRs are stale: `"silent"` (post nothing) or `"celebrate"` (post a 🎉 message). |
+
+### Secrets:
+| Secret | Required | Description |
+|--------|----------|-------------|
+| `SLACK_APP_TOKEN` | **Yes** | Slack bot token with `chat:write` scope. Bot must be in the target channel. |
+| `ANTHROPIC_API_KEY` | If `use-ai-curation: true` | Anthropic API key. If missing while AI curation is enabled, the AI step is skipped and the deterministic message ships. |
+
+### Permissions:
+The workflow declares its own `pull-requests: read` and `contents: read`. The caller does not need to pass any extra permissions.
+
+### Behaviour notes:
+- **Volume-aware**: deterministic mode hard-caps focus to `max-prs-to-surface`; the rest is summarised by area. The threaded breakdown carries the long tail so the main channel stays scannable even at 100+ open PRs.
+- **Non-blocking AI**: the Anthropic call has a 2-minute step timeout and `continue-on-error: true`. If it fails, the digest ships without the AI headline / focus, falling back to oldest-first.
+- **Area detection**: PRs are auto-grouped by the first label matching the canonical area set (`hub`, `api-gateway`, `control-v2`, `portals`, `installers`, `control`, `ocpp-toolkit`, `storybook`, `dependencies`, `security`). Anything else falls into `other`.
+- **Cost (Sonnet, ~100 PRs)**: roughly ~$0.04 per run, ~$1/month for weekday-only scheduling.
+- **Scheduling**: GitHub Actions cron runs in UTC. For 9 AM Europe/Copenhagen year-round, use dual cron entries plus a small timezone guard in the caller (see the monorepo-typescript `automation-pr-digest.yml` for the canonical pattern).
+
+### Example Usage:
+
+#### Basic — daily digest for a single channel:
+```yaml
+name: PR digest
+
+on:
+  schedule:
+    - cron: "7 7 * * 1-5"  # 09:07 CEST (summer)
+    - cron: "7 8 * * 1-5"  # 09:07 CET  (winter)
+  workflow_dispatch:
+
+jobs:
+  schedule-guard:
+    runs-on: ubuntu-latest
+    outputs:
+      proceed: ${{ steps.check.outputs.proceed }}
+    steps:
+      - id: check
+        run: |
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            echo "proceed=true" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+          LOCAL_HOUR=$(TZ=Europe/Copenhagen date +%H)
+          if [[ "$LOCAL_HOUR" == "09" ]]; then
+            echo "proceed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "proceed=false (local hour=$LOCAL_HOUR)"
+            echo "proceed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  digest:
+    needs: schedule-guard
+    if: needs.schedule-guard.outputs.proceed == 'true'
+    uses: monta-app/github-workflows/.github/workflows/pr-digest.yml@main
+    with:
+      slack-channel-id: C0ALEGFRPU1
+      stale-threshold-days: 2
+      critical-threshold-days: 7
+      title: "my-repo — open PRs"
+    secrets: inherit
+```
+
+#### Low-volume repo — flat list, no AI:
+```yaml
+jobs:
+  digest:
+    uses: monta-app/github-workflows/.github/workflows/pr-digest.yml@main
+    with:
+      slack-channel-id: C0XXXXXXXXX
+      use-ai-curation: false
+      post-thread-breakdown: false
+      empty-state: celebrate
+    secrets:
+      SLACK_APP_TOKEN: ${{ secrets.SLACK_APP_TOKEN }}
+```
+
+### Manual testing:
+The workflow supports `workflow_dispatch`. Trigger from the GitHub UI ("Actions" tab → workflow → "Run workflow") or via the CLI:
+
+```bash
+gh workflow run automation-pr-digest.yml --repo monta-app/<your-repo>
+```
+
+The first manual run is the recommended way to verify channel membership, secrets, and AI model availability before relying on the schedule.

--- a/docs/workflow-guide.md
+++ b/docs/workflow-guide.md
@@ -1228,7 +1228,7 @@ For additional support, check the workflow logs in GitHub Actions or contact the
 | `include-drafts` | No | `false` | Include draft PRs in the digest. |
 | `exclude-authors` | No | `"dependabot[bot],renovate[bot]"` | Comma-separated GitHub logins to exclude. |
 | `use-ai-curation` | No | `true` | Use Claude to pick focus PRs and write the headline. Falls back gracefully if the call fails. |
-| `model` | No | `"claude-sonnet-4-7"` | Anthropic model identifier. Use `claude-haiku-4-5` for ~10× cheaper, slightly less nuanced output. |
+| `model` | No | `"claude-sonnet-4-6"` | Anthropic model identifier ([model list](https://docs.anthropic.com/en/docs/about-claude/models/overview)). Use `claude-haiku-4-5` for ~10× cheaper, slightly less nuanced output. |
 | `post-thread-breakdown` | No | `true` | Reply in-thread with the full per-area PR breakdown. |
 | `title` | No | repo name | Header text for the Slack message. |
 | `empty-state` | No | `"silent"` | When no PRs are stale: `"silent"` (post nothing) or `"celebrate"` (post a 🎉 message). |
@@ -1307,10 +1307,12 @@ jobs:
 ```
 
 ### Manual testing:
-The workflow supports `workflow_dispatch`. Trigger from the GitHub UI ("Actions" tab → workflow → "Run workflow") or via the CLI:
+This reusable workflow only declares `workflow_call` — it cannot be dispatched directly. Manual testing is done via the **caller workflow** in the consuming repository, which must declare `workflow_dispatch` itself (both example callers above do).
+
+Once the caller is in place, trigger from the GitHub UI ("Actions" tab → caller workflow → "Run workflow") or via the CLI:
 
 ```bash
-gh workflow run automation-pr-digest.yml --repo monta-app/<your-repo>
+gh workflow run <caller-workflow-filename>.yml --repo monta-app/<your-repo>
 ```
 
 The first manual run is the recommended way to verify channel membership, secrets, and AI model availability before relying on the schedule.


### PR DESCRIPTION
## What?

Adds a new reusable workflow at `.github/workflows/pr-digest.yml` that any Monta repo can call to post a daily Slack digest of its open pull requests. Updates `README.md` and `docs/workflow-guide.md` with usage examples.

The message is **AI-curated by default**: a compact JSON of open-PR metadata is sent to Claude, which produces a 1–2 sentence headline plus up to N focus PRs with one-line "why this matters" notes. The deterministic Block Kit builder then renders the full Slack message — header counts, AI headline, today's focus, critical PRs, area summary, deep links. A threaded reply carries the full per-area breakdown so the channel stays scannable at high volume.

Caller-tunable via inputs: `slack-channel-id`, `stale-threshold-days` (2), `critical-threshold-days` (7), `max-prs-to-surface` (5), `use-ai-curation` (true), `model` (`claude-sonnet-4-7`), `post-thread-breakdown` (true), `empty-state` (silent), `include-drafts` (false), `exclude-authors`, `title`.

Secrets: `SLACK_APP_TOKEN` (existing org/repo secret used by ~20 deploy workflows) and `ANTHROPIC_API_KEY` (only when AI curation is enabled — falls back gracefully if missing or the call fails).

## Why?

Built for high-volume repos like `monorepo-typescript` (100+ open PRs). A flat list of every open PR is unreadable and hits Slack's 50-block ceiling; a smart curated view ("here are the 5 things to act on today, by area") is the only thing that scales. Designed to be reusable so any other repo can adopt the same digest with a ~20-line caller workflow.

Complements the existing `automation-stale-prs.yml` housekeeper (which closes PRs after 14 days of inactivity) by surfacing them to the team early.

## Context

Consumer workflow lands in parallel: https://github.com/monta-app/monorepo-typescript/pull/new/feat/NOJIRA/pr-digest

That PR must wait for this one to merge — it references `monta-app/github-workflows/.github/workflows/pr-digest.yml@main`.