### PR TITLE
fix(pr-digest): wrap thread-breakdown string concat in parens

### DIFF
--- a/.github/workflows/pr-digest.yml
+++ b/.github/workflows/pr-digest.yml
@@ -415,8 +415,8 @@ jobs:
                         { type: "section",
                           text: {
                             type: "mrkdwn",
-                            text: "*`\(.area)`* — \(.prs | length) stale\n" +
-                                  (.prs | map(prLine(.)) | join("\n"))
+                            text: ("*`\(.area)`* — \(.prs | length) stale\n"
+                                   + (.prs | map(prLine(.)) | join("\n")))
                           } } ]
                     ) | flatten)
                 )


### PR DESCRIPTION
## What?

Fixes a jq parse error in the `Post thread breakdown` step of the `pr-digest.yml` reusable workflow:

```
jq: error: syntax error, unexpected '+', expecting '}' (Unix shell quoting issues?)
    text: "*\`\(.area)\`* — \(.prs | length) stale\n" +
```

The cause: a multi-line string-concatenation `+` inside an object-literal value, without parentheses to group the expression. jq consumed the string, expected `}` to close the object, and choked on the `+`. Wrapping the concatenation in parens disambiguates the parser and matches the pattern already used in the main-message step.

## Why?

Caught on the first real production run against `monta-app/monorepo-typescript` (112 open PRs, 29 stale, 5 critical). The main digest posted to Slack successfully (✅ visible in `#monta-eng`), but the thread reply step crashed with the above error and no breakdown was posted.

This fix is isolated to two lines — string concat semantics unchanged, just parenthesised.

## Context

- Production run that surfaced the bug: https://github.com/monta-app/monorepo-typescript/actions/runs/26662056815/job/78586768458
- Original reusable workflow PR: https://github.com/monta-app/github-workflows/pull/293