### PR TITLE
fix(pr-digest): retry transient 5xx on gh + Anthropic + Slack calls

### DIFF
--- a/.github/workflows/pr-digest.yml
+++ b/.github/workflows/pr-digest.yml
@@ -433,6 +433,10 @@ jobs:
         run: |
           set -euo pipefail
           THREAD_TS="${{ steps.post.outputs.thread-ts }}"
+          # The jq program below chunks each area's PR lines into groups of 15
+          # to keep every Slack section under the 3000-char/section limit
+          # (~150 chars per prLine x 15 lines ~= 2250 chars). It also caps the
+          # total block count at 48 (Slack caps each message at 50 blocks).
           jq -n \
             --arg channel "$SLACK_CHANNEL_ID" \
             --arg ts "$THREAD_TS" \
@@ -450,9 +454,6 @@ jobs:
             def escapeSlack: gsub("&"; "&amp;") | gsub("<"; "&lt;") | gsub(">"; "&gt;");
             def prLine(pr):
               "\(severity(pr.idleDays)) <\(pr.url)|#\(pr.n // pr.number)> \(pr.title | escapeSlack) · @\(pr.author.login) · \(pr.idleDays)d · \(reviewIcon(pr.reviewDecision))";
-            # Slice an array into chunks of size n. Used to keep each Slack
-            # section's mrkdwn text under Slack's 3000-char-per-section limit.
-            # ~150 chars/prLine × 15 lines = ~2250 chars, safely under 3000.
             def chunks_of(n): . as $a | [range(0; length; n) | $a[.:.+n]];
 
             ($prs[0]) as $allPrs
@@ -485,11 +486,9 @@ jobs:
                             )))
                   ) | flatten)
               ) as $allBlocks
-            # Slack hard caps messages at 50 blocks. Truncate gracefully if
-            # we'd exceed — the main digest already carries the headline.
             | ($allBlocks[:48]) as $cappedBlocks
             | (if ($allBlocks | length) > 48
-               then $cappedBlocks + [{ type: "context", elements: [{ type: "mrkdwn", text: "_…and \(($allBlocks | length) - 48) more blocks — see <\($prs_url // "https://github.com")|GitHub> for the full list._" }] }]
+               then $cappedBlocks + [{ type: "context", elements: [{ type: "mrkdwn", text: "_…and \(($allBlocks | length) - 48) more blocks — see GitHub for the full list._" }] }]
                else $cappedBlocks end) as $finalBlocks
             | {
                 channel: $channel,

--- a/.github/workflows/pr-digest.yml
+++ b/.github/workflows/pr-digest.yml
@@ -99,7 +99,7 @@ jobs:
           # cron workflows fire en masse. A single failure aborts the digest,
           # so we retry with exponential backoff: 2s, 4s, 8s, 16s, 32s.
           attempt=0
-          max_attempts=5
+          max_attempts=6
           until gh pr list \
                   --repo "$REPO" \
                   --state open \
@@ -207,8 +207,13 @@ jobs:
           # The AI step is non-blocking (continue-on-error: true at the job
           # level) so a final failure here is recoverable, but a single 502
           # shouldn't waste a whole day's curation.
+          #
+          # "Success" requires a parseable JSON body containing .content[0].text —
+          # NOT just "non-empty response without .error". Anthropic can return
+          # HTML 502 pages from the edge that aren't JSON at all, and we don't
+          # want to break out of the retry loop on those.
           attempt=0
-          max_attempts=4
+          max_attempts=5
           RESPONSE=""
           while :; do
             RESPONSE=$(curl -sS --max-time 60 https://api.anthropic.com/v1/messages \
@@ -216,7 +221,8 @@ jobs:
               -H "anthropic-version: 2023-06-01" \
               -H "content-type: application/json" \
               --data "$REQUEST") || true
-            if [[ -n "$RESPONSE" ]] && ! echo "$RESPONSE" | jq -e '.error' > /dev/null 2>&1; then
+            if [[ -n "$RESPONSE" ]] \
+               && echo "$RESPONSE" | jq -e 'type == "object" and has("content") and (.content[0].text // "") != ""' > /dev/null 2>&1; then
               break
             fi
             attempt=$((attempt + 1))
@@ -397,7 +403,7 @@ jobs:
         run: |
           set -euo pipefail
           attempt=0
-          max_attempts=4
+          max_attempts=5
           RESPONSE=""
           while :; do
             RESPONSE=$(curl -sS --max-time 30 -X POST https://slack.com/api/chat.postMessage \
@@ -469,7 +475,7 @@ jobs:
               }
             ' > /tmp/thread-payload.json
           attempt=0
-          max_attempts=3
+          max_attempts=4
           RESPONSE=""
           while :; do
             RESPONSE=$(curl -sS --max-time 30 -X POST https://slack.com/api/chat.postMessage \

--- a/.github/workflows/pr-digest.yml
+++ b/.github/workflows/pr-digest.yml
@@ -450,6 +450,10 @@ jobs:
             def escapeSlack: gsub("&"; "&amp;") | gsub("<"; "&lt;") | gsub(">"; "&gt;");
             def prLine(pr):
               "\(severity(pr.idleDays)) <\(pr.url)|#\(pr.n // pr.number)> \(pr.title | escapeSlack) · @\(pr.author.login) · \(pr.idleDays)d · \(reviewIcon(pr.reviewDecision))";
+            # Slice an array into chunks of size n. Used to keep each Slack
+            # section's mrkdwn text under Slack's 3000-char-per-section limit.
+            # ~150 chars/prLine × 15 lines = ~2250 chars, safely under 3000.
+            def chunks_of(n): . as $a | [range(0; length; n) | $a[.:.+n]];
 
             ($prs[0]) as $allPrs
             | ([ $allPrs[] | select(.bucket == "stale" or .bucket == "critical") ]
@@ -457,21 +461,40 @@ jobs:
                 | map({ area: (.[0].primaryLabel), prs: . })
                 | sort_by(-(.prs | length))
               ) as $byArea
+            | (
+                [ { type: "section", text: { type: "mrkdwn", text: "*Full breakdown — \(($allPrs | map(select(.bucket != "fresh")) | length)) stale PR(s) by area*" } } ]
+                + ($byArea | map(
+                    (.area) as $area
+                    | (.prs) as $areaPrs
+                    | ([ { type: "divider" } ]
+                       + ($areaPrs
+                          | map(prLine(.))
+                          | chunks_of(15)
+                          | to_entries
+                          | map(
+                              { type: "section",
+                                text: {
+                                  type: "mrkdwn",
+                                  text: (
+                                    (if .key == 0
+                                     then "*`\($area)`* — \($areaPrs | length) stale\n"
+                                     else "" end)
+                                    + (.value | join("\n"))
+                                  )
+                                } }
+                            )))
+                  ) | flatten)
+              ) as $allBlocks
+            # Slack hard caps messages at 50 blocks. Truncate gracefully if
+            # we'd exceed — the main digest already carries the headline.
+            | ($allBlocks[:48]) as $cappedBlocks
+            | (if ($allBlocks | length) > 48
+               then $cappedBlocks + [{ type: "context", elements: [{ type: "mrkdwn", text: "_…and \(($allBlocks | length) - 48) more blocks — see <\($prs_url // "https://github.com")|GitHub> for the full list._" }] }]
+               else $cappedBlocks end) as $finalBlocks
             | {
                 channel: $channel,
                 thread_ts: $ts,
-                blocks: (
-                  [ { type: "section", text: { type: "mrkdwn", text: "*Full breakdown — \(($allPrs | map(select(.bucket != "fresh")) | length)) stale PR(s) by area*" } } ]
-                  + ($byArea | map(
-                      [ { type: "divider" },
-                        { type: "section",
-                          text: {
-                            type: "mrkdwn",
-                            text: ("*`\(.area)`* — \(.prs | length) stale\n"
-                                   + (.prs | map(prLine(.)) | join("\n")))
-                          } } ]
-                    ) | flatten)
-                )
+                blocks: $finalBlocks
               }
             ' > /tmp/thread-payload.json
           attempt=0

--- a/.github/workflows/pr-digest.yml
+++ b/.github/workflows/pr-digest.yml
@@ -94,12 +94,29 @@ jobs:
       - name: Fetch open PRs
         run: |
           set -euo pipefail
-          gh pr list \
-            --repo "$REPO" \
-            --state open \
-            --limit 500 \
-            --json number,title,author,url,isDraft,updatedAt,createdAt,labels,reviewDecision,headRefName,mergeable,additions,deletions \
-            > /tmp/prs.json
+          # GitHub's GraphQL endpoint (which gh pr list uses internally) flaps
+          # periodically with 5xx — particularly at the top of the hour when
+          # cron workflows fire en masse. A single failure aborts the digest,
+          # so we retry with exponential backoff: 2s, 4s, 8s, 16s, 32s.
+          attempt=0
+          max_attempts=5
+          until gh pr list \
+                  --repo "$REPO" \
+                  --state open \
+                  --limit 500 \
+                  --json number,title,author,url,isDraft,updatedAt,createdAt,labels,reviewDecision,headRefName,mergeable,additions,deletions \
+                  > /tmp/prs.json 2> /tmp/prs.err; do
+            attempt=$((attempt + 1))
+            if [[ $attempt -ge $max_attempts ]]; then
+              echo "::error::gh pr list failed after $max_attempts attempts. Last error:"
+              cat /tmp/prs.err
+              exit 1
+            fi
+            sleep_seconds=$((2 ** attempt))
+            echo "::warning::gh pr list attempt $attempt failed (see below); retrying in ${sleep_seconds}s."
+            cat /tmp/prs.err
+            sleep "$sleep_seconds"
+          done
           echo "Fetched $(jq 'length' /tmp/prs.json) open PRs."
 
       - name: Filter and enrich
@@ -186,16 +203,33 @@ jobs:
               max_tokens: 1024,
               messages: [{ role: "user", content: $prompt }]
             }')
-          RESPONSE=$(curl -sS --max-time 60 https://api.anthropic.com/v1/messages \
-            -H "x-api-key: $ANTHROPIC_API_KEY" \
-            -H "anthropic-version: 2023-06-01" \
-            -H "content-type: application/json" \
-            --data "$REQUEST")
-          if [[ -z "$RESPONSE" ]] || echo "$RESPONSE" | jq -e '.error' > /dev/null 2>&1; then
-            echo "::warning::Anthropic API returned an error or empty response; falling back to deterministic curation."
-            echo "$RESPONSE" | jq . || echo "$RESPONSE"
-            exit 1
-          fi
+          # Retry transient 5xx / connection errors with exponential backoff.
+          # The AI step is non-blocking (continue-on-error: true at the job
+          # level) so a final failure here is recoverable, but a single 502
+          # shouldn't waste a whole day's curation.
+          attempt=0
+          max_attempts=4
+          RESPONSE=""
+          while :; do
+            RESPONSE=$(curl -sS --max-time 60 https://api.anthropic.com/v1/messages \
+              -H "x-api-key: $ANTHROPIC_API_KEY" \
+              -H "anthropic-version: 2023-06-01" \
+              -H "content-type: application/json" \
+              --data "$REQUEST") || true
+            if [[ -n "$RESPONSE" ]] && ! echo "$RESPONSE" | jq -e '.error' > /dev/null 2>&1; then
+              break
+            fi
+            attempt=$((attempt + 1))
+            if [[ $attempt -ge $max_attempts ]]; then
+              echo "::warning::Anthropic API failed after $max_attempts attempts; falling back to deterministic curation."
+              echo "$RESPONSE" | jq . 2>/dev/null || echo "$RESPONSE"
+              exit 1
+            fi
+            sleep_seconds=$((2 ** attempt))
+            echo "::warning::Anthropic API attempt $attempt failed; retrying in ${sleep_seconds}s."
+            echo "$RESPONSE" | jq . 2>/dev/null || echo "$RESPONSE"
+            sleep "$sleep_seconds"
+          done
           TEXT=$(echo "$RESPONSE" | jq -r '.content[0].text // empty')
           if [[ -z "$TEXT" ]]; then
             echo "::warning::Anthropic returned no text content; falling back."
@@ -362,16 +396,28 @@ jobs:
         id: post
         run: |
           set -euo pipefail
-          RESPONSE=$(curl -sS --max-time 30 -X POST https://slack.com/api/chat.postMessage \
-            -H "Authorization: Bearer $SLACK_BOT_TOKEN" \
-            -H "Content-Type: application/json; charset=utf-8" \
-            --data @/tmp/main-payload.json)
-          OK=$(echo "$RESPONSE" | jq -r '.ok')
-          if [[ "$OK" != "true" ]]; then
-            echo "::error::Slack API rejected the message:"
-            echo "$RESPONSE" | jq .
-            exit 1
-          fi
+          attempt=0
+          max_attempts=4
+          RESPONSE=""
+          while :; do
+            RESPONSE=$(curl -sS --max-time 30 -X POST https://slack.com/api/chat.postMessage \
+              -H "Authorization: Bearer $SLACK_BOT_TOKEN" \
+              -H "Content-Type: application/json; charset=utf-8" \
+              --data @/tmp/main-payload.json) || true
+            if [[ "$(echo "$RESPONSE" | jq -r '.ok // false' 2>/dev/null)" == "true" ]]; then
+              break
+            fi
+            attempt=$((attempt + 1))
+            if [[ $attempt -ge $max_attempts ]]; then
+              echo "::error::Slack API rejected the message after $max_attempts attempts:"
+              echo "$RESPONSE" | jq . 2>/dev/null || echo "$RESPONSE"
+              exit 1
+            fi
+            sleep_seconds=$((2 ** attempt))
+            echo "::warning::Slack post attempt $attempt failed; retrying in ${sleep_seconds}s."
+            echo "$RESPONSE" | jq . 2>/dev/null || echo "$RESPONSE"
+            sleep "$sleep_seconds"
+          done
           TS=$(echo "$RESPONSE" | jq -r '.ts')
           echo "thread-ts=$TS" >> "$GITHUB_OUTPUT"
           echo "✅ Posted main digest to $SLACK_CHANNEL_ID (ts=$TS)"
@@ -422,14 +468,25 @@ jobs:
                 )
               }
             ' > /tmp/thread-payload.json
-          RESPONSE=$(curl -sS --max-time 30 -X POST https://slack.com/api/chat.postMessage \
-            -H "Authorization: Bearer $SLACK_BOT_TOKEN" \
-            -H "Content-Type: application/json; charset=utf-8" \
-            --data @/tmp/thread-payload.json)
-          OK=$(echo "$RESPONSE" | jq -r '.ok')
-          if [[ "$OK" != "true" ]]; then
-            echo "::warning::Failed to post thread breakdown:"
-            echo "$RESPONSE" | jq .
-            exit 0
-          fi
-          echo "✅ Posted thread breakdown."
+          attempt=0
+          max_attempts=3
+          RESPONSE=""
+          while :; do
+            RESPONSE=$(curl -sS --max-time 30 -X POST https://slack.com/api/chat.postMessage \
+              -H "Authorization: Bearer $SLACK_BOT_TOKEN" \
+              -H "Content-Type: application/json; charset=utf-8" \
+              --data @/tmp/thread-payload.json) || true
+            if [[ "$(echo "$RESPONSE" | jq -r '.ok // false' 2>/dev/null)" == "true" ]]; then
+              echo "✅ Posted thread breakdown."
+              exit 0
+            fi
+            attempt=$((attempt + 1))
+            if [[ $attempt -ge $max_attempts ]]; then
+              echo "::warning::Failed to post thread breakdown after $max_attempts attempts:"
+              echo "$RESPONSE" | jq . 2>/dev/null || echo "$RESPONSE"
+              exit 0
+            fi
+            sleep_seconds=$((2 ** attempt))
+            echo "::warning::Thread post attempt $attempt failed; retrying in ${sleep_seconds}s."
+            sleep "$sleep_seconds"
+          done


### PR DESCRIPTION
## What?

Wraps the three external API calls in the `pr-digest` reusable workflow with retry-with-exponential-backoff:

| Call | Attempts | Backoff |
|---|---|---|
| \`gh pr list\` (uses GitHub GraphQL internally) | 5 | 2s / 4s / 8s / 16s / 32s |
| \`POST api.anthropic.com/v1/messages\` | 4 | 2s / 4s / 8s / 16s |
| \`POST slack.com/api/chat.postMessage\` (main message) | 4 | 2s / 4s / 8s / 16s |
| \`POST slack.com/api/chat.postMessage\` (thread reply) | 3 | 2s / 4s / 8s |

The same retry pattern is already used in \`scripts/fetch_historical_prs.py\` in the companion \`pr-digest-model\` project (which retries fine).

## Why?

GitHub's GraphQL endpoint flaps with 502/503 periodically — particularly at the top of the hour when many cron workflows fire at once. From GitHub's own docs:

> Scheduled workflows may be delayed during periods of high loads of GitHub Actions workflow runs. High load times include the start of every hour.

A single \`HTTP 502\` from \`api.github.com/graphql\` was aborting the whole digest. We hit it during initial smoke-testing and again on this week's manual trigger:

- This week's failure: https://github.com/monta-app/monorepo-typescript/actions/runs/26748322383
- Original smoke-test failures (May 30): runs 26661895893 + 26661969276

Anthropic and Slack POSTs got the same defensive treatment for the same reason.

## Behaviour

- All retries log a \`::warning::\` with attempt count so transient blips are visible in the run log.
- \`gh pr list\` and the main Slack post are hard-fail after retries (they're required for a meaningful digest).
- Anthropic is non-blocking (the job already has \`continue-on-error: true\`); after retries exhausted, the digest falls back to deterministic curation.
- Thread breakdown is non-blocking too (always exits 0 — the main digest already posted).