### PR TITLE
feat(deploy-ocpp-gateway): add optional infra-portal-context input

### DIFF
--- a/.github/actions/deploy-ocpp-gateway/action.yml
+++ b/.github/actions/deploy-ocpp-gateway/action.yml
@@ -16,6 +16,10 @@ inputs:
   infra-portal-token:
     description: 'Infra Portal token'
     required: true
+  infra-portal-context:
+    description: 'Kube context the infra-portal releaser should target (e.g. main-staging). Defaults to ocpp-<cluster> derived from stage.'
+    required: false
+    default: ''
 
 runs:
   using: 'composite'
@@ -42,7 +46,13 @@ runs:
           cluster=production
           path_prefix=""
         fi
-        response_code=$(curl --write-out '%{http_code}' --silent -o resp_body.txt -X POST -H "Authorization: Bearer ${{ inputs.infra-portal-token }}" -H "Content-Type: application/json" -d '{"commitHash": "'"${{ github.sha }}"'", "buildNumber": "'"${{ github.run_number }}"'", "awsAccountId": "'"${{ inputs.aws-account-id }}"'", "replicas": ${{ inputs.ocpp-gateway-replicas }}}' https://${{ steps.set-infra-portal-server.outputs.infra-portal-hostname }}${path_prefix}/ocpp-${cluster}/${{ inputs.service-identifier }}-${{ inputs.stage }}/create-gateway-release)
+        context="${{ inputs.infra-portal-context }}"
+        if [[ -z "$context" ]]; then
+          context="ocpp-${cluster}"
+        fi
+        release_url="https://${{ steps.set-infra-portal-server.outputs.infra-portal-hostname }}${path_prefix}/${context}/${{ inputs.service-identifier }}-${{ inputs.stage }}/create-gateway-release"
+        echo "Posting gateway release to ${release_url}"
+        response_code=$(curl --write-out '%{http_code}' --silent -o resp_body.txt -X POST -H "Authorization: Bearer ${{ inputs.infra-portal-token }}" -H "Content-Type: application/json" -d '{"commitHash": "'"${{ github.sha }}"'", "buildNumber": "'"${{ github.run_number }}"'", "awsAccountId": "'"${{ inputs.aws-account-id }}"'", "replicas": ${{ inputs.ocpp-gateway-replicas }}}' "${release_url}")
         if [[ $response_code != "200" ]]; then
           echo "::error::$(cat resp_body.txt)"
           exit 1


### PR DESCRIPTION
## Summary
The `deploy-ocpp-gateway` composite action builds the infra-portal releaser URL with a hardcoded context segment:

```
{host}{path_prefix}/ocpp-${cluster}/{service-identifier}-{stage}/create-gateway-release
```

OCPP gateway **staging** has moved to the `main-staging` cluster (image + ArgoCD already migrated via service-ocpp#2978), but the blue/green releaser call still drives the old `ocpp-staging` context.

This adds an **optional** `infra-portal-context` input:
- when provided → used as the context segment
- when omitted → falls back to `ocpp-${cluster}` (existing behavior, so production and any other caller are unchanged)

Also echoes the final URL in the job log for verification.

## URL rendering (tested)
| Caller | URL |
|---|---|
| staging + `infra-portal-context: main-staging` | `https://infra-portal.internal.monta.app/api/public/main-staging/ocpp-gateway-staging/create-gateway-release` |
| staging, no input (today) | `https://infra-portal.internal.monta.app/api/public/ocpp-staging/ocpp-gateway-staging/create-gateway-release` |
| production, no input | `https://infra-portal.monta.app/ocpp-production/ocpp-gateway-production/create-gateway-release` |

The `/api/public/:context/:namespace/create-gateway-release` route in infra-portal authenticates with a static token (context-independent) and resolves `:context` to a kubeconfig — `main-staging` is already a known context there.

## Follow-up
service-ocpp `deploy-gateway-staging.yml` will pass `infra-portal-context: "main-staging"` and bump its pinned action SHA (separate PR, depends on this one's merge SHA). Production workflow stays untouched.

Part of the ocpp-staging cluster decommission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)