### PR TITLE
ci(pull-request-kotlin): persist Gradle build-cache across runs (split restore/save) [NO-JIRA]

### DIFF
--- a/.github/workflows/pull-request-kotlin.yml
+++ b/.github/workflows/pull-request-kotlin.yml
@@ -90,14 +90,27 @@ jobs:
         with:
           distribution: corretto
           java-version: ${{ inputs.java-version }}
-          cache: 'gradle'
-      - name: Cache SonarCloud packages
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+      - name: Restore Gradle cache
+        id: gradle-cache
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ github.head_ref }}-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-${{ github.head_ref }}-
+            ${{ runner.os }}-gradle-
+      - name: Restore SonarCloud cache
+        id: sonar-cache
         if: ${{ !inputs.skip-sonar }}
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: ~/.sonar/cache
-          key: ${{ runner.os }}-sonar
-          restore-keys: ${{ runner.os }}-sonar
+          key: ${{ runner.os }}-sonar-${{ github.head_ref }}-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-sonar-${{ github.head_ref }}-
+            ${{ runner.os }}-sonar-
       - name: Run linter
         env:
           GHL_USERNAME: ${{ secrets.GHL_USERNAME }}
@@ -158,3 +171,17 @@ jobs:
             **/build/test-results/**/*.xml
             **/build/test-results/**/*.trx
             **/build/test-results/**/*.json
+      - name: Save Gradle cache
+        if: ${{ always() && steps.gradle-cache.outputs.cache-hit != 'true' }}
+        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ github.head_ref }}-${{ github.sha }}
+      - name: Save SonarCloud cache
+        if: ${{ always() && !inputs.skip-sonar && steps.sonar-cache.outputs.cache-hit != 'true' }}
+        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+        with:
+          path: ~/.sonar/cache
+          key: ${{ runner.os }}-sonar-${{ github.head_ref }}-${{ github.sha }}


### PR DESCRIPTION
## Problem

The Kotlin PR test job recompiles **~2m 30s** of KSP + Kotlin every run, even for unchanged modules. Dependencies are cached, but `setup-java`'s built-in `cache: 'gradle'` keys on the gradle files and only **saves on a cache miss** — so Gradle's build-cache (`~/.gradle/caches/build-cache-1`, the compiled task output) is written once and frozen, and every run recompiles from scratch. The Sonar cache (fixed key `${{ runner.os }}-sonar`) has the same freeze.

## Fix

Switch both caches to the **split `restore`/`save`** pattern and save on **every run** under a per-commit, branch-scoped key, so the build-cache persists and unchanged `kspKotlin`/`compileKotlin` come back **FROM-CACHE**.

```
key:          ${{ runner.os }}-gradle-${{ github.head_ref }}-${{ github.sha }}
restore-keys: ${{ runner.os }}-gradle-${{ github.head_ref }}-   # this branch's latest (tightest hit)
              ${{ runner.os }}-gradle-                           # fallback: most recent run
```
- `save` runs on `always()` (compiled output is cached even when tests fail) and is skipped on an exact re-run hit.
- Caches are isolated **per repository automatically** (GitHub + runs-on), so no `${{ github.repository }}` is needed in the key.

## Validated on a canary (`service-feature` #737)

Two runs through this branch ref — cold, then warm (identical source):

| Step | Cold (run 1) | Warm (run 2) |
|---|---|---|
| Restore Gradle cache | 0s (miss) | 10s (hit, ~690 MB @ 260 MB/s) |
| Run linter (ktlint + compile) | **3m 46s** | **12s** |
| Run tests with coverage | **3m 53s** | **13s** |
| Upload to SonarCloud | 52s | 36s |
| Save caches | 10s | 15s |
| **Total** | **9m 11s** | **1m 56s** |

Log confirms: `Cache hit for restore-key: …-gradle-…` → `compileKotlin FROM-CACHE`, `kspKotlin FROM-CACHE`, `ktlint… FROM-CACHE`.

**Caveat on the 1m 56s:** run 2 had byte-identical source (empty commit), so even the `test` task cache-hit. A real PR that changes code still recompiles changed files and **re-runs affected tests** (~2m 17s of real `internal-api` test execution). So the dependable win is **eliminating the ~2m 30s–3m 40s cold recompile**; expect a typical code PR around **~4–5 min** (from ~9 min), and a docs/no-op PR the full ~1m 56s.

## Notes

- Build-cache win only materialises for repos with `org.gradle.caching=true` (harmless no-op otherwise); dependency caching helps every repo.
- Per-commit keys mean more cache writes — fine on runs-on (no size cap, 10-day lifecycle).
- Branch isolation: the `-gradle-` fallback can pull another PR's cache on a *cold first build* of a new branch — low risk for this PR-only, ships-nothing workflow, and moot if runs-on enforces branch-scoping on the magic cache.

## ⚠️ Blast radius

`pull-request-kotlin.yml@main` is consumed by **35 repos** — merging flips all of them on their next PR run. Two repos pin a SHA (`service-charges`, `service-internal-ocpi-tooling-service`) and are unaffected. Consider migrating a couple via the branch ref first as a wider canary before merging to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)