### PR TITLE
ci(pr-title-check): bump action-check-pr-title to v6.0.0 (Node 24) [NO-JIRA]

### DIFF
--- a/.github/actions/pr-title-check/action.yaml
+++ b/.github/actions/pr-title-check/action.yaml
@@ -4,7 +4,7 @@ runs:
   using: composite
   steps:
     - name: Check PR title
-      uses: Slashgear/action-check-pr-title@860e8dc639f8e60335a6f5e8936ba67ed2536890 # v4
+      uses: Slashgear/action-check-pr-title@76166c63ec0b25cdbe693e5e972e83ca186313fb # v6.0.0
       with:
         regexp: '^(\[(develop|development|staging)\]\s)?(build|chore|ci|docs|feat|feature|fix|perf|refactor|revert|style|test|release|ignore)(\([\w\- ]+\))?!?: (.+)'
         helpMessage: "Example: 'feat(app-ui): Add new dashboard component (WEB-123)'"


### PR DESCRIPTION
## Summary

The `pr-title-check` composite action pins `Slashgear/action-check-pr-title` at the **v4** SHA (`860e8dc`), which runs on **Node.js 20**. GitHub is deprecating Node 20 on Actions runners (forced to Node 24 on **2026-06-16**, Node 20 removed **2026-09-16**), so every consumer repo currently logs this warning on its `Pull Request … / Setup` job:

> Node.js 20 actions are deprecated … Slashgear/action-check-pr-title@860e8dc… Please check if updated versions … support Node.js 24.

## Change

Bump the pin to **v6.0.0** (`76166c63ec0b25cdbe693e5e972e83ca186313fb`), whose `action.yml` declares `runs.using: "node24"`.

## Compatibility

- Inputs are unchanged — v6 still supports `regexp` and `helpMessage` (plus an optional `flags`), exactly how this action calls it. Drop-in upgrade.
- v6's only breaking change is requiring **Actions runner v2.327.1+**, satisfied by GitHub-hosted runners and our current ARC self-hosted runners.

This is the single shared definition, so the fix propagates to all repos that consume `pull-request-kotlin.yml@main` (service-feature, etc.) automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)