### PR TITLE
ci(pull-request-kotlin): single Gradle invocation for ktlint + test + kover [NO-JIRA]

### DIFF
--- a/.github/workflows/pull-request-kotlin.yml
+++ b/.github/workflows/pull-request-kotlin.yml
@@ -111,7 +111,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-sonar-${{ github.head_ref }}-
             ${{ runner.os }}-sonar-
-      - name: Run linter
+      - name: Lint & test with coverage
         env:
           GHL_USERNAME: ${{ secrets.GHL_USERNAME }}
           GHL_PASSWORD: ${{ secrets.GHL_PASSWORD }}
@@ -119,18 +119,8 @@ jobs:
         uses: monta-app/github-workflows/.github/actions/gradle-multi-module@main
         with:
           gradle-module: ${{ inputs.gradle-module }}
-          gradle-tasks: 'ktlintCheck'
-          gradle-args: ${{ inputs.gradle-args }}
-      - name: Run tests with coverage
-        env:
-          GHL_USERNAME: ${{ secrets.GHL_USERNAME }}
-          GHL_PASSWORD: ${{ secrets.GHL_PASSWORD }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        uses: monta-app/github-workflows/.github/actions/gradle-multi-module@main
-        with:
-          gradle-module: ${{ inputs.gradle-module }}
-          gradle-tasks: 'test koverXmlReport koverHtmlReport'
-          gradle-args: ${{ inputs.gradle-args }}
+          gradle-tasks: 'ktlintCheck test koverXmlReport koverHtmlReport'
+          gradle-args: ${{ inputs.gradle-args }} --continue
       - name: Upload test results
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7


### PR DESCRIPTION
## What

Merge the `ktlintCheck`, `test`, and kover tasks into a **single Gradle invocation** in the Kotlin PR test job (was two separate `./gradlew --no-daemon` runs). Sonar stays its own step.

## Why

The linter and test steps are two separate `--no-daemon` invocations, so Gradle pays **configuration + KSP/JVM startup twice**. On a cold run that's ~1m of config before the first task even runs in the linter step, then again in the test step. The **main compile is already reused** between them (on-disk `UP-TO-DATE` — verified: `compileKotlin UP-TO-DATE` in the test invocation), so the duplication is purely per-invocation overhead, not recompilation.

One invocation pays that overhead once.

`--continue` runs all tasks even if one fails, so a **ktlint failure no longer hides test results** — previously the separate test step was skipped when the linter step failed.

## Scope / risk

- Follow-up to #298 (same workflow, same 35-repo blast radius). Behaviour-preserving except the `--continue` improvement above.
- Sonar unchanged (still conditional on `skip-sonar`, still skipped if the combined step fails).
- For multi-module callers (`gradle-module` set), tasks are module-prefixed exactly as before.

## Expected impact

Saves the redundant Gradle config/startup (~30s–1m on cold runs; a smaller slice on warm). Modest on its own — the bigger remaining lever is test execution (ClickHouse testcontainers + `maxParallelForks`), tracked separately.

Will canary on `service-feature` (cold + warm) before merging to `@main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)