### PR TITLE
ci(sonar-cloud): warm PR builds via a Linux-gradle-main- baseline cache [NO-JIRA]

### DIFF
--- a/.github/workflows/sonar-cloud.yml
+++ b/.github/workflows/sonar-cloud.yml
@@ -63,7 +63,16 @@ jobs:
         with:
           distribution: corretto
           java-version: ${{ inputs.java-version }}
-          cache: 'gradle'
+      - name: Restore Gradle cache
+        id: gradle-cache
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-main-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-main-
       - name: Cache SonarCloud packages
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
@@ -90,3 +99,11 @@ jobs:
             **/build/reports/problems/**
           if-no-files-found: ignore
           retention-days: 30
+      - name: Save Gradle cache
+        if: ${{ always() && github.ref == 'refs/heads/main' && steps.gradle-cache.outputs.cache-hit != 'true' }}
+        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-main-${{ github.sha }}


### PR DESCRIPTION
## What

Make the main analysis build publish a `Linux-gradle-main-<sha>` cache, so the Kotlin **PR** test workflow's fresh-branch builds start warm.

## Why

`pull-request-kotlin.yml` (#298) caches `~/.gradle` per-branch with a `…-gradle-` fallback — but GitHub/runs-on caches are **branch-scoped**: a run can only restore caches from **its own ref** + the **default branch (main)**. Sibling PR caches are invisible, and the PR test workflow **never runs on main**, so there's no `Linux-gradle-*` cache on main to fall back to → **every fresh branch's first build is cold** (~3–4m recompile). (Confirmed from the cache list: all `Linux-gradle-*` entries sit on `refs/pull/*` / branch refs, none on `refs/heads/main`.)

## How

`sonar-cloud.yml` already compiles + tests on main (`code-analysis.yml` on `push: main`). Give it the #298 split-cache treatment:
- Replace `setup-java`'s frozen `cache: 'gradle'` with `actions/cache/restore` (`key: …-gradle-main-<sha>`, restore-key `…-gradle-main-`).
- `actions/cache/save` `…-gradle-main-<sha>` at the end.

That cache lands on `refs/heads/main` (default branch) → the PR test workflow's existing `…-gradle-` fallback matches it → **fresh PR branches start warm**. **No change to `pull-request-kotlin.yml` needed.**

**Safety:** the save is guarded `github.ref == 'refs/heads/main'`, so a PR-context run of this workflow can never write (poison) the trusted main baseline.

## Scope

- Shared workflow, same 35-repo blast radius as #298. Restoring/saving only affects timing; SonarCloud analysis is unchanged.
- Left the existing `~/.sonar/cache` step as-is (separate, small).

## Canary plan

On `service-feature`: merge → main runs `code-analysis` (seeds `Linux-gradle-main-`), then open a fresh PR and confirm its **first** build restores the main cache and compiles `FROM-CACHE` (vs today's ~3–4m cold).

🤖 Generated with [Claude Code](https://claude.com/claude-code)