### PR TITLE
fix(ci): stable SonarQube scanner cache key for PRs [NOJIRA]

### DIFF
--- a/.github/workflows/pull-request-kotlin.yml
+++ b/.github/workflows/pull-request-kotlin.yml
@@ -112,9 +112,6 @@ jobs:
         uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: ~/.sonar/cache
-          # Stable key (matches sonar-cloud.yml) so PRs reuse the warm cache
-          # populated by the main-branch scan, instead of missing on every
-          # branch+sha and re-downloading the scanner JRE + analyzer plugins.
           key: ${{ runner.os }}-sonar
           restore-keys: ${{ runner.os }}-sonar
       - name: Run linter

--- a/.github/workflows/pull-request-kotlin.yml
+++ b/.github/workflows/pull-request-kotlin.yml
@@ -112,10 +112,11 @@ jobs:
         uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: ~/.sonar/cache
-          key: ${{ runner.os }}-sonar-${{ github.head_ref }}-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-sonar-${{ github.head_ref }}-
-            ${{ runner.os }}-sonar-
+          # Stable key (matches sonar-cloud.yml) so PRs reuse the warm cache
+          # populated by the main-branch scan, instead of missing on every
+          # branch+sha and re-downloading the scanner JRE + analyzer plugins.
+          key: ${{ runner.os }}-sonar
+          restore-keys: ${{ runner.os }}-sonar
       - name: Run linter
         env:
           GHL_USERNAME: ${{ secrets.GHL_USERNAME }}
@@ -194,9 +195,9 @@ jobs:
             ~/.gradle/caches
             ~/.gradle/wrapper
           key: ${{ runner.os }}-gradle-${{ github.head_ref }}-${{ github.sha }}
-      - name: Save SonarCloud cache
+      - name: Save SonarQube cache
         if: ${{ always() && !inputs.skip-sonar && steps.sonar-cache.outputs.cache-hit != 'true' }}
         uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: ~/.sonar/cache
-          key: ${{ runner.os }}-sonar-${{ github.head_ref }}-${{ github.sha }}
+          key: ${{ runner.os }}-sonar


### PR DESCRIPTION
## Problem
`pull-request-kotlin.yml` caches `~/.sonar/cache` with key `${{ runner.os }}-sonar-${{ github.head_ref }}-${{ github.sha }}` and restore-key `${{ runner.os }}-sonar-`.

- The branch+sha key means **every commit on every PR is a fresh key** → miss.
- The restore-key `…-sonar-` (trailing dash) **never matches** the main-branch cache saved by `sonar-cloud.yml`, which uses `${{ runner.os }}-sonar` (no dash).
- PR-only caches aren't shared across branches, so there's nothing to fall back to.

Net: **every PR re-downloads the scanner JRE + analyzer plugins** — adds minutes, and is the source of the intermittent `Call to .../api/v2/analysis/jres/… failed: stream was reset` failures.

## Fix
Align the PR workflow to the **same stable `${{ runner.os }}-sonar` key** that `sonar-cloud.yml` (main-branch) already uses, so PRs restore the warm cache populated on `main`. (Cache is immutable per key, so the save no-ops when the hit is from main; it self-refreshes on the 7-day eviction cycle.)

Fixes the cache miss seen across the Kotlin fleet (e.g. service-wallet PRs).

## Follow-up (separate, discussed)
`-Dsonar.scanner.skipJreProvisioning=true` to skip the JRE download entirely (runners already have Corretto JDK) — bigger reliability win, will propose separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)