### PR TITLE
Add sonar-non-blocking input to pull-request-kotlin workflow

### DIFF
--- a/.github/workflows/pull-request-kotlin.yml
+++ b/.github/workflows/pull-request-kotlin.yml
@@ -35,6 +35,11 @@ on:
         type: boolean
         description: "Allow you to skip using Sonar Cloud, only to be used for common modules"
         default: false
+      sonar-non-blocking:
+        required: false
+        type: boolean
+        description: "When true, a failure of the 'Upload results to SonarQube' step does not fail the job"
+        default: false
       gradle-args:
         required: false
         type: string
@@ -159,6 +164,7 @@ jobs:
           args: "--login-server https://headscale.monta.com --accept-routes"
       - name: Upload results to SonarQube
         if: ${{ !inputs.skip-sonar }}
+        continue-on-error: ${{ inputs.sonar-non-blocking }}
         env:
           GHL_USERNAME: ${{ secrets.GHL_USERNAME }}
           GHL_PASSWORD: ${{ secrets.GHL_PASSWORD }}


### PR DESCRIPTION
## What

Adds an opt-in boolean input `sonar-non-blocking` (default `false`) to the reusable `pull-request-kotlin.yml` workflow. When set to `true`, it applies `continue-on-error: ${{ inputs.sonar-non-blocking }}` to the **Upload results to SonarQube** step, so a failure of that step no longer fails the job.

## Why

The `Upload results to SonarQube` step in service-wallet's CI intermittently fails (e.g. [this run](https://github.com/monta-app/service-wallet/actions/runs/27606676520/job/81620392247?pr=4465)), blocking otherwise-green PRs. Requested by Linus Eriksson.

Default is `false`, so **behaviour is unchanged for every repo that doesn't opt in**. service-wallet opts in via a separate PR (monta-app/service-wallet) which should merge after this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)