### PR TITLE
build: drop x86/amd64 image builds, go ARM64-only

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -4,11 +4,7 @@
 self-hosted-runner:
   # Define custom self-hosted runner labels
   labels:
-    - linux-x64
-    - linux-x64-xl
     - linux-arm64
     - linux-arm64-xl
-    - self-hosted-x64
-    - self-hosted-x64-2xl
     - self-hosted-arm64
     - self-hosted-arm64-2xl

--- a/.github/actions/runner-size-converter/README.md
+++ b/.github/actions/runner-size-converter/README.md
@@ -1,6 +1,6 @@
 # Runner Size Converter Action
 
-A composite action that converts runner size and architecture inputs into GitHub runner names.
+A composite action that converts a runner size into an arm64 GitHub runner name.
 
 ## Usage
 
@@ -10,7 +10,6 @@ A composite action that converts runner size and architecture inputs into GitHub
   uses: monta-app/github-workflows/.github/actions/runner-size-converter@main
   with:
     runner-size: 'large'
-    architecture: 'arm64'  # Optional, defaults to 'x64'
 
 - name: Use runner
   runs-on: ${{ steps.runner.outputs.runner-name }}
@@ -23,19 +22,16 @@ A composite action that converts runner size and architecture inputs into GitHub
 | Input | Required | Default | Description |
 |-------|----------|---------|-------------|
 | `runner-size` | Yes | - | Runner size: `normal` or `large` |
-| `architecture` | No | `x64` | Runner architecture: `x64` or `arm64` |
 
 ## Outputs
 
 | Output | Description |
 |--------|-------------|
-| `runner-name` | The converted runner name (e.g., `linux-x64-xl`) |
+| `runner-name` | The converted runner name (e.g., `linux-arm64-xl`) |
 
 ## Runner Mapping
 
-| Size | Architecture | Output |
-|------|--------------|--------|
-| `normal` | `x64` | `linux-x64` |
-| `large` | `x64` | `linux-x64-xl` |
-| `normal` | `arm64` | `linux-arm64` |
-| `large` | `arm64` | `linux-arm64-xl` |
+| Size | Output |
+|------|--------|
+| `normal` | `linux-arm64` |
+| `large` | `linux-arm64-xl` |

--- a/.github/actions/runner-size-converter/action.yml
+++ b/.github/actions/runner-size-converter/action.yml
@@ -1,15 +1,11 @@
 name: 'Runner Size Converter'
-description: 'Convert runner size and architecture to GitHub runner names'
+description: 'Convert a runner size into an arm64 GitHub runner name'
 author: 'Your Organization'
 
 inputs:
   runner-size:
     description: 'Runner size (normal or large)'
     required: true
-  architecture:
-    description: 'Runner architecture (x64 or arm64)'
-    required: false
-    default: 'x64'
 
 outputs:
   runner-name:
@@ -23,19 +19,8 @@ runs:
       id: convert
       shell: bash
       run: |
-        ARCH="${{ inputs.architecture }}"
         SIZE="${{ inputs.runner-size }}"
-        
-        # Validate architecture
-        case "$ARCH" in
-          "x64"|"arm64")
-            ;;
-          *)
-            echo "Error: Invalid architecture '$ARCH'. Must be 'x64' or 'arm64'"
-            exit 1
-            ;;
-        esac
-        
+
         # Validate size
         case "$SIZE" in
           "normal"|"large")
@@ -45,12 +30,12 @@ runs:
             exit 1
             ;;
         esac
-        
-        # Build runner name
-        RUNNER_NAME="linux-$ARCH"
+
+        # Build runner name (arm64 only)
+        RUNNER_NAME="linux-arm64"
         if [ "$SIZE" = "large" ]; then
           RUNNER_NAME="$RUNNER_NAME-xl"
         fi
-        
+
         echo "runner-name=$RUNNER_NAME" >> $GITHUB_OUTPUT
         echo "Selected runner: $RUNNER_NAME"

--- a/.github/workflows/code-coverage-kotlin.yml
+++ b/.github/workflows/code-coverage-kotlin.yml
@@ -11,11 +11,6 @@ on:
         type: string
         description: "Runner to use for the job (normal, or large)"
         default: "normal"
-      architecture:
-        required: false
-        type: string
-        description: "Runner architecture (x64 or arm64)"
-        default: "x64"
       java-version:
         required: false
         type: string
@@ -89,7 +84,6 @@ jobs:
         uses: monta-app/github-workflows/.github/actions/runner-size-converter@main
         with:
           runner-size: ${{ inputs.runner-size }}
-          architecture: ${{ inputs.architecture }}
   generate-coverage-report:
     needs:
       - setup

--- a/.github/workflows/component-build.yml
+++ b/.github/workflows/component-build.yml
@@ -84,7 +84,7 @@ on:
     outputs:
       image-tag:
         description: 'The image tag that was built'
-        value: ${{ jobs.create-manifest.outputs.image-tag }}
+        value: ${{ jobs.build.outputs.image-tag }}
 
 permissions:
   id-token: write
@@ -96,39 +96,24 @@ jobs:
     runs-on: linux-arm64
     timeout-minutes: 5
     outputs:
-      runner-x64: ${{ steps.runner-x64.outputs.runner-name }}
-      runner-arm64: ${{ steps.runner-arm64.outputs.runner-name }}
+      runner: ${{ steps.runner.outputs.runner-name }}
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           ref: ${{ inputs.git-sha || github.sha }}
-      - name: Get x64 runner name
-        id: runner-x64
+      - name: Get runner name
+        id: runner
         uses: monta-app/github-workflows/.github/actions/runner-size-converter@main
         with:
           runner-size: ${{ inputs.runner-size }}
-          architecture: x64
-      - name: Get arm64 runner name
-        id: runner-arm64
-        uses: monta-app/github-workflows/.github/actions/runner-size-converter@main
-        with:
-          runner-size: ${{ inputs.runner-size }}
-          architecture: arm64
   build:
-    name: Build Multi-Arch
+    name: Build
     needs: setup
-    runs-on: ${{ matrix.runner }}
+    runs-on: ${{ needs.setup.outputs.runner }}
     timeout-minutes: 30
-    strategy:
-      matrix:
-        include:
-          - platform: linux/amd64
-            arch: amd64
-            runner: ${{ needs.setup.outputs.runner-x64 }}
-          - platform: linux/arm64
-            arch: arm64
-            runner: ${{ needs.setup.outputs.runner-arm64 }}
+    outputs:
+      image-tag: ${{ inputs.git-sha || github.sha }}
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
@@ -154,8 +139,8 @@ jobs:
         with:
           images: ${{ steps.login-ecr.outputs.registry }}/${{ inputs.ecr-repository-name || format('{0}-{1}', inputs.service-identifier, inputs.stage) }}
           tags: |
-            type=raw,value=${{ inputs.git-sha || github.sha }},suffix=-${{ matrix.arch }}
-            type=raw,value=latest,suffix=-${{ matrix.arch }}
+            type=raw,value=${{ inputs.git-sha || github.sha }}
+            type=raw,value=latest
       - name: Build and push
         id: build
         uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
@@ -165,19 +150,19 @@ jobs:
           context: .
           file: ./${{ inputs.docker-file-name }}
           push: true
-          # Disable provenance and SBOM to keep single-platform images simple (not manifest lists).
-          # Required for manual multi-arch manifest creation in create-manifest job.
-          # Note: provenance: false alone is insufficient with newer BuildKit versions;
-          # BUILDX_NO_DEFAULT_ATTESTATIONS=1 is also needed to prevent attestation
-          # manifests from being generated, which turn images into manifest lists.
+          platforms: linux/arm64
+          # Disable provenance and SBOM attestations so the pushed tag is a plain
+          # single-arch image manifest, not a manifest list. provenance: false alone
+          # is insufficient with newer BuildKit versions; BUILDX_NO_DEFAULT_ATTESTATIONS=1
+          # is also needed to stop attestation manifests turning the image into a list.
           provenance: false
           sbom: false
-          # Registry-backed BuildKit cache, scoped per-arch to keep amd64/arm64 caches separate.
-          # Cache lives in the same ECR repo as the image under a dedicated tag, so existing
-          # ecr-put-image IAM permissions cover it. mode=max exports all intermediate layers
-          # (and cache mount contents on BuildKit ≥0.12) for maximum reuse on the next build.
-          cache-from: ${{ inputs.enable-buildkit-cache && format('type=registry,ref={0}/{1}:buildcache-{2}', steps.login-ecr.outputs.registry, inputs.ecr-repository-name || format('{0}-{1}', inputs.service-identifier, inputs.stage), matrix.arch) || '' }}
-          cache-to: ${{ inputs.enable-buildkit-cache && format('type=registry,ref={0}/{1}:buildcache-{2},mode=max,image-manifest=true,oci-mediatypes=true', steps.login-ecr.outputs.registry, inputs.ecr-repository-name || format('{0}-{1}', inputs.service-identifier, inputs.stage), matrix.arch) || '' }}
+          # Registry-backed BuildKit cache. Cache lives in the same ECR repo as the
+          # image under a dedicated tag, so existing ecr-put-image IAM permissions
+          # cover it. mode=max exports all intermediate layers (and cache mount
+          # contents on BuildKit ≥0.12) for maximum reuse on the next build.
+          cache-from: ${{ inputs.enable-buildkit-cache && format('type=registry,ref={0}/{1}:buildcache', steps.login-ecr.outputs.registry, inputs.ecr-repository-name || format('{0}-{1}', inputs.service-identifier, inputs.stage)) || '' }}
+          cache-to: ${{ inputs.enable-buildkit-cache && format('type=registry,ref={0}/{1}:buildcache,mode=max,image-manifest=true,oci-mediatypes=true', steps.login-ecr.outputs.registry, inputs.ecr-repository-name || format('{0}-{1}', inputs.service-identifier, inputs.stage)) || '' }}
           build-args: |
             ${{ inputs.additional-build-args }}
           labels: |
@@ -194,42 +179,3 @@ jobs:
             LOKALISE_TOKEN=${{ secrets.LOKALISE_TOKEN }}
             LOKALISE_PROJECT_ID=${{ secrets.LOKALISE_PROJECT_ID }}
             NEXT_SERVER_ACTIONS_ENCRYPTION_KEY=${{ secrets.NEXT_SERVER_ACTIONS_ENCRYPTION_KEY }}
-  create-manifest:
-    name: Create Multi-Arch Manifest
-    needs: build
-    runs-on: linux-arm64
-    timeout-minutes: 10
-    outputs:
-      image-tag: ${{ inputs.git-sha || github.sha }}
-    steps:
-      - name: Configure AWS credentials via assumed role
-        uses: aws-actions/configure-aws-credentials@e7f100cf4c008499ea8adda475de1042d6975c7b # v6
-        with:
-          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/ecr-put-image
-          role-session-name: create-manifest-${{ inputs.service-identifier }}-${{inputs.stage}}
-          aws-region: ${{ inputs.region }}
-      - name: Login to Amazon ECR
-        id: login-ecr
-        uses: aws-actions/amazon-ecr-login@fa648b43de3d4d023bcb3f89ed6940096949c419 # v2
-      - name: Create and push manifest
-        run: |
-          # Enable experimental features
-          export DOCKER_CLI_EXPERIMENTAL=enabled
-
-          # Define the base image name and tag
-          BASE_IMAGE="${{ steps.login-ecr.outputs.registry }}/${{ inputs.ecr-repository-name || format('{0}-{1}', inputs.service-identifier, inputs.stage) }}"
-          SHA_TAG="${{ inputs.git-sha || github.sha }}"
-
-          # Create manifest list
-          docker manifest create ${BASE_IMAGE}:${SHA_TAG} \
-            ${BASE_IMAGE}:${SHA_TAG}-amd64 \
-            ${BASE_IMAGE}:${SHA_TAG}-arm64
-
-          # Push the manifest
-          docker manifest push ${BASE_IMAGE}:${SHA_TAG}
-
-          # Create and push latest manifest
-          docker manifest create ${BASE_IMAGE}:latest \
-            ${BASE_IMAGE}:latest-amd64 \
-            ${BASE_IMAGE}:latest-arm64
-          docker manifest push ${BASE_IMAGE}:latest

--- a/.github/workflows/component-test-kotlin.yml
+++ b/.github/workflows/component-test-kotlin.yml
@@ -6,11 +6,6 @@ on:
         required: false
         type: string
         description: 'Runner size for the component-runner-size-converter'
-      architecture:
-        required: false
-        type: string
-        description: "Runner architecture (x64 or arm64)"
-        default: "x64"
       service-name:
         required: false
         type: string
@@ -57,7 +52,6 @@ jobs:
         uses: monta-app/github-workflows/.github/actions/runner-size-converter@main
         with:
           runner-size: ${{ inputs.runner-size }}
-          architecture: ${{ inputs.architecture }}
   test:
     name: Test
     needs: setup

--- a/.github/workflows/component-test-python.yml
+++ b/.github/workflows/component-test-python.yml
@@ -6,11 +6,6 @@ on:
         required: false
         type: string
         description: 'Runner size for the component-runner-size-converter'
-      architecture:
-        required: false
-        type: string
-        description: "Runner architecture (x64 or arm64)"
-        default: "x64"
       service-name:
         required: false
         type: string
@@ -59,7 +54,6 @@ jobs:
         uses: monta-app/github-workflows/.github/actions/runner-size-converter@main
         with:
           runner-size: ${{ inputs.runner-size }}
-          architecture: ${{ inputs.architecture }}
   test:
     name: Test
     needs: setup

--- a/.github/workflows/deploy-generic-v2.yml
+++ b/.github/workflows/deploy-generic-v2.yml
@@ -8,11 +8,14 @@ on:
         type: string
         description: "Runner to use for the job (normal, or large)"
         default: "normal"
+      # DEPRECATED (no-op): all builds and CI run on arm64. Retained for backwards
+      # compatibility with callers still passing it; the value is ignored and this
+      # input will be removed in a future release.
       architecture:
         required: false
         type: string
-        description: "Runner architecture (x64 or arm64)"
-        default: "x64"
+        description: "[DEPRECATED] Ignored - all builds and CI run on arm64. No-op kept for backwards compatibility; will be removed in a future release."
+        default: "arm64"
       stage:
         required: true
         type: string

--- a/.github/workflows/deploy-generic.yml
+++ b/.github/workflows/deploy-generic.yml
@@ -8,11 +8,14 @@ on:
         type: string
         description: "Runner to use for the job (normal, or large)"
         default: "normal"
+      # DEPRECATED (no-op): all builds and CI run on arm64. Retained for backwards
+      # compatibility with callers still passing it; the value is ignored and this
+      # input will be removed in a future release.
       architecture:
         required: false
         type: string
-        description: "Runner architecture (x64 or arm64)"
-        default: "x64"
+        description: "[DEPRECATED] Ignored - all builds and CI run on arm64. No-op kept for backwards compatibility; will be removed in a future release."
+        default: "arm64"
       stage:
         required: true
         type: string

--- a/.github/workflows/deploy-kotlin-v2.yml
+++ b/.github/workflows/deploy-kotlin-v2.yml
@@ -8,6 +8,14 @@ on:
         type: string
         description: "Runner to use for the job (normal, or large)"
         default: "normal"
+      # DEPRECATED (no-op): all builds and CI run on arm64. Retained for backwards
+      # compatibility with callers still passing it; the value is ignored and this
+      # input will be removed in a future release.
+      architecture:
+        required: false
+        type: string
+        description: "[DEPRECATED] Ignored - all builds and CI run on arm64. No-op kept for backwards compatibility; will be removed in a future release."
+        default: "arm64"
       stage:
         required: true
         type: string

--- a/.github/workflows/deploy-kotlin.yml
+++ b/.github/workflows/deploy-kotlin.yml
@@ -8,11 +8,14 @@ on:
         type: string
         description: "Runner to use for the job (normal, or large)"
         default: "normal"
+      # DEPRECATED (no-op): all builds and CI run on arm64. Retained for backwards
+      # compatibility with callers still passing it; the value is ignored and this
+      # input will be removed in a future release.
       architecture:
         required: false
         type: string
-        description: "Runner architecture (x64 or arm64)"
-        default: "x64"
+        description: "[DEPRECATED] Ignored - all builds and CI run on arm64. No-op kept for backwards compatibility; will be removed in a future release."
+        default: "arm64"
       stage:
         required: true
         type: string
@@ -210,7 +213,6 @@ jobs:
     uses: ./.github/workflows/component-test-kotlin.yml
     with:
       runner-size: ${{ inputs.runner-size }}
-      architecture: ${{ inputs.architecture }}
       service-name: ${{ inputs.service-name }}
       service-emoji: ${{ inputs.service-emoji }}
       gradle-module: ${{ inputs.gradle-module }}

--- a/.github/workflows/deploy-python.yml
+++ b/.github/workflows/deploy-python.yml
@@ -8,11 +8,14 @@ on:
         type: string
         description: "Runner to use for the job (normal, or large)"
         default: "normal"
+      # DEPRECATED (no-op): all builds and CI run on arm64. Retained for backwards
+      # compatibility with callers still passing it; the value is ignored and this
+      # input will be removed in a future release.
       architecture:
         required: false
         type: string
-        description: "Runner architecture (x64 or arm64)"
-        default: "x64"
+        description: "[DEPRECATED] Ignored - all builds and CI run on arm64. No-op kept for backwards compatibility; will be removed in a future release."
+        default: "arm64"
       stage:
         required: true
         type: string
@@ -101,7 +104,6 @@ jobs:
     uses: ./.github/workflows/component-test-python.yml
     with:
       runner-size: ${{ inputs.runner-size }}
-      architecture: ${{ inputs.architecture }}
       service-name: ${{ inputs.service-name }}
       service-emoji: ${{ inputs.service-emoji }}
       docker-compose-path: ${{ inputs.docker-compose-path }}

--- a/.github/workflows/pull-request-bun.yml
+++ b/.github/workflows/pull-request-bun.yml
@@ -7,11 +7,14 @@ on:
         type: string
         description: "Runner to use for the job (normal, or large)"
         default: "normal"
+      # DEPRECATED (no-op): all builds and CI run on arm64. Retained for backwards
+      # compatibility with callers still passing it; the value is ignored and this
+      # input will be removed in a future release.
       architecture:
         required: false
         type: string
-        description: "Runner architecture (x64 or arm64)"
-        default: "x64"
+        description: "[DEPRECATED] Ignored - all builds and CI run on arm64. No-op kept for backwards compatibility; will be removed in a future release."
+        default: "arm64"
       bun-version:
         required: false
         type: string
@@ -61,7 +64,6 @@ jobs:
         uses: monta-app/github-workflows/.github/actions/runner-size-converter@main
         with:
           runner-size: ${{ inputs.runner-size }}
-          architecture: ${{ inputs.architecture }}
   lint-build-test:
     name: Lint & Build & Test
     needs: setup

--- a/.github/workflows/pull-request-kotlin.yml
+++ b/.github/workflows/pull-request-kotlin.yml
@@ -7,11 +7,14 @@ on:
         type: string
         description: "Runner to use for the job (normal, or large)"
         default: "normal"
+      # DEPRECATED (no-op): all builds and CI run on arm64. Retained for backwards
+      # compatibility with callers still passing it; the value is ignored and this
+      # input will be removed in a future release.
       architecture:
         required: false
         type: string
-        description: "Runner architecture (x64 or arm64)"
-        default: "x64"
+        description: "[DEPRECATED] Ignored - all builds and CI run on arm64. No-op kept for backwards compatibility; will be removed in a future release."
+        default: "arm64"
       java-version:
         required: false
         type: string
@@ -79,7 +82,6 @@ jobs:
         uses: monta-app/github-workflows/.github/actions/runner-size-converter@main
         with:
           runner-size: ${{ inputs.runner-size }}
-          architecture: ${{ inputs.architecture }}
   test:
     name: Test with code coverage
     needs: setup

--- a/.github/workflows/pull-request-react.yml
+++ b/.github/workflows/pull-request-react.yml
@@ -7,11 +7,14 @@ on:
         type: string
         description: "Runner to use for the job (normal, or large)"
         default: "normal"
+      # DEPRECATED (no-op): all builds and CI run on arm64. Retained for backwards
+      # compatibility with callers still passing it; the value is ignored and this
+      # input will be removed in a future release.
       architecture:
         required: false
         type: string
-        description: "Runner architecture (x64 or arm64)"
-        default: "x64"
+        description: "[DEPRECATED] Ignored - all builds and CI run on arm64. No-op kept for backwards compatibility; will be removed in a future release."
+        default: "arm64"
       node-version:
         required: false
         type: string
@@ -67,7 +70,6 @@ jobs:
         uses: monta-app/github-workflows/.github/actions/runner-size-converter@main
         with:
           runner-size: ${{ inputs.runner-size }}
-          architecture: ${{ inputs.architecture }}
   lint-build-test:
     name: Lint & Build & Test
     needs: setup

--- a/.github/workflows/sonar-cloud.yml
+++ b/.github/workflows/sonar-cloud.yml
@@ -7,11 +7,14 @@ on:
         type: string
         description: "Runner to use for the job (normal, or large)"
         default: "normal"
+      # DEPRECATED (no-op): all builds and CI run on arm64. Retained for backwards
+      # compatibility with callers still passing it; the value is ignored and this
+      # input will be removed in a future release.
       architecture:
         required: false
         type: string
-        description: "Runner architecture (x64 or arm64)"
-        default: "x64"
+        description: "[DEPRECATED] Ignored - all builds and CI run on arm64. No-op kept for backwards compatibility; will be removed in a future release."
+        default: "arm64"
       java-version:
         required: false
         type: string
@@ -50,7 +53,6 @@ jobs:
         uses: monta-app/github-workflows/.github/actions/runner-size-converter@main
         with:
           runner-size: ${{ inputs.runner-size }}
-          architecture: ${{ inputs.architecture }}
   sonar-cloud:
     name: SonarQube Analysis
     needs: setup

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,11 +1,19 @@
 # Claude Code Notes
 
 ## Last Documentation Update
-- **Date**: 2026-02-23
-- **Latest SHA**: b65d4f5 (check for newer commits)
-- **Changes**: Created `deploy-kotlin-v2.yml` workflow for repo-based Kotlin service deployments
+- **Date**: 2026-06-17
+- **Latest SHA**: bf4f995 (check for newer commits)
+- **Changes**: Removed all x86/amd64 image building; builds are now ARM64-only
 
-## Recent Workflow Changes (2026-02-23)
+## Recent Workflow Changes (2026-06-17)
+1. **ARM64-only image builds**: Purged all x86/amd64 support from the build and CI surface
+   - `component-build.yml`: removed the amd64+arm64 build matrix and the `create-manifest` job. Now does a single native ARM64 build (`platforms: linux/arm64`) that pushes the `<sha>` and `latest` tags directly, with no per-arch suffixes and no multi-arch manifest list. The setup job resolves a single arm64 runner and the buildcache is no longer per-arch scoped.
+   - `runner-size-converter` action: dropped the `architecture` input; always emits `linux-arm64` / `linux-arm64-xl`.
+   - `architecture` input: stopped forwarding it anywhere (it no longer selects a runner). Removed entirely from the internal/analysis workflows (`code-coverage-kotlin`, `component-test-kotlin`, `component-test-python`). On the entry-point workflows service repos call directly (`pull-request-{kotlin,bun,react}`, `sonar-cloud`, `deploy-{kotlin,kotlin-v2,python,generic,generic-v2}`) it is RETAINED as a deprecated no-op: the value is ignored, the description marks it deprecated, and `deploy-kotlin-v2` gains it for v1/v2 parity. Slated for removal in a future release.
+   - `actionlint.yaml`: removed the `linux-x64`, `linux-x64-xl`, `self-hosted-x64`, `self-hosted-x64-2xl` labels.
+   - **Breaking for callers**: only repos calling the internal workflows (`code-coverage-kotlin`, `component-test-kotlin`, `component-test-python`) directly with `architecture:` must drop that input. Callers of the deploy / pull-request / sonar-cloud entry points are unaffected (the input is accepted and ignored).
+
+## Previous Changes (2026-02-23)
 1. **Kotlin V2 Deploy Workflow**: Created `deploy-kotlin-v2.yml` for repo-based deployments
    - Uses `component-deploy-v2.yml` for service repository-based deployment pattern
    - Includes all Kotlin-specific features: tests, Gradle, service profile updates, release tags, changelog

--- a/docs/v3-migration-guide.md
+++ b/docs/v3-migration-guide.md
@@ -177,4 +177,4 @@ jobs:
 - **Security**: Secrets not in image layers
 - **Performance**: BuildKit caching
 - **Simplicity**: Fewer parameters needed
-- **Multi-arch**: ARM64 and AMD64 support
+- **ARM64**: Native ARM64 image builds

--- a/docs/workflow-guide.md
+++ b/docs/workflow-guide.md
@@ -142,14 +142,13 @@ jobs:
 ## Component Build
 
 **File:** `component-build.yml`  
-**Purpose:** Builds multi-architecture Docker images and pushes them to Amazon ECR.
+**Purpose:** Builds an ARM64 Docker image and pushes it to Amazon ECR.
 
 ### What it does:
 1. Updates Slack with build progress
-2. Builds Docker images for both AMD64 and ARM64 architectures
-3. Pushes images to ECR with architecture-specific tags
-4. Creates a multi-arch manifest
-5. Notifies Slack of build completion
+2. Builds a single-platform ARM64 Docker image
+3. Pushes the image to ECR tagged with the commit SHA and `latest`
+4. Notifies Slack of build completion
 
 ### Inputs:
 | Input | Required | Default | Description |
@@ -393,7 +392,7 @@ jobs:
 1. **Create Release Tag** (optional): Creates a release tag when triggered via workflow_dispatch and `enable-release-tag` is true
 2. **Initialize**: Sets up Slack notifications for the deployment process
 3. **Test**: Runs unit tests and validates code quality
-4. **Build**: Creates multi-architecture Docker images and pushes to ECR
+4. **Build**: Builds an ARM64 Docker image and pushes to ECR
 5. **Deploy**: Updates Kubernetes manifests for deployment
 6. **Create Changelog** (optional): Generates and publishes changelog to Slack and GitHub releases
 
@@ -510,7 +509,7 @@ jobs:
 ### What it does:
 1. Initializes Slack notification
 2. Runs Python tests using pytest and uv
-3. Builds multi-arch Docker images
+3. Builds an ARM64 Docker image
 4. Deploys to Kubernetes via manifest updates
 
 ### Inputs:
@@ -576,7 +575,7 @@ jobs:
 ### What it does:
 1. **Initialize**: Sets up Slack notifications for the deployment process
 2. **Test**: Runs unit tests and validates code quality (optional, controlled by `run-tests`)
-3. **Build**: Creates multi-architecture Docker images and pushes to ECR
+3. **Build**: Builds an ARM64 Docker image and pushes to ECR
 4. **Deploy**: Updates helm values in the service repository and syncs with ArgoCD
 5. **Update Service Profile** (optional): Generates linkerd service profile from OpenAPI spec
 6. **Create Release Tag** (optional): Creates a release tag when `enable-release-tag` is true


### PR DESCRIPTION
## What

Removes all x86/amd64 Docker image building. Images are now built ARM64-only.

## Why

Our runners and production nodes are all arm64, so building amd64 images and stitching a multi-arch manifest list was wasted build time and extra complexity for an artifact nothing pulls.

## Changes

### Image build (`component-build.yml`)
- Single native ARM64 build (`platforms: linux/arm64`) that pushes the `<sha>` and `latest` tags directly.
- Removed the amd64 + arm64 build matrix and the separate `create-manifest` job that built the multi-arch manifest list.
- Dropped the per-arch tag suffixes (`-amd64` / `-arm64`) and per-arch buildcache scoping (now a single `buildcache` tag).

### Runner selection
- `runner-size-converter` drops the `architecture` input and always resolves an arm64 runner (`linux-arm64` / `linux-arm64-xl`).
- `architecture` is no longer forwarded to the converter or sub-workflows anywhere.
- `actionlint.yaml`: removed the `linux-x64`, `linux-x64-xl`, `self-hosted-x64` and `self-hosted-x64-2xl` labels.

### `architecture` input
- Removed entirely from the internal workflows: `code-coverage-kotlin`, `component-test-kotlin`, `component-test-python`.
- Kept as a deprecated no-op (declared, ignored, marked deprecated in its description) on the entry-point workflows service repos call directly: `pull-request-{kotlin,bun,react}`, `sonar-cloud`, `deploy-{kotlin,kotlin-v2,python,generic,generic-v2}`. `deploy-kotlin-v2` gains it for v1/v2 parity.

### Docs
- Updated `workflow-guide.md`, `v3-migration-guide.md`, the `runner-size-converter` README, and `CLAUDE.md`.

## Breaking changes

Only repos that call the internal workflows (`code-coverage-kotlin`, `component-test-kotlin`, `component-test-python`) directly with `architecture:` need to drop that input. Callers of the deploy, pull-request and sonar-cloud entry points are unaffected; the input is still accepted and ignored.

## Validation

actionlint passes on all workflows. The only finding is a pre-existing shellcheck note in `track-pending-release.yml`, which this PR does not touch.
