### PR TITLE
feat: opt-in multi-arch builds in component-build [ENERGY-2009]

### DIFF
--- a/.github/workflows/component-build.yml
+++ b/.github/workflows/component-build.yml
@@ -50,6 +50,11 @@ on:
         required: false
         type: string
         description: 'Git SHA to checkout and build from. Defaults to the triggering commit SHA.'
+      platforms:
+        required: false
+        type: string
+        default: "linux/arm64"
+        description: 'Target build platforms. Defaults to arm64-only (single-arch). Set to a comma-separated list (e.g. "linux/amd64,linux/arm64") to push a multi-arch manifest; cross-arch builds run under QEMU emulation.'
     secrets:
       AWS_ACCOUNT_ID:
         required: true
@@ -139,6 +144,9 @@ jobs:
           tags: |
             type=raw,value=${{ inputs.git-sha || github.sha }}
             type=raw,value=latest
+      - name: Set up QEMU for cross-platform build
+        if: ${{ inputs.platforms != 'linux/arm64' }}
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
       - name: Set up Blacksmith Docker builder
         uses: useblacksmith/setup-docker-builder@ab5c1da94f53f5cd75c1038092aa276dddfccbba # v1
       - name: Build and push
@@ -150,7 +158,7 @@ jobs:
           context: .
           file: ./${{ inputs.docker-file-name }}
           push: true
-          platforms: linux/arm64
+          platforms: ${{ inputs.platforms }}
           # provenance/sbom off (with BUILDX_NO_DEFAULT_ATTESTATIONS=1 above) so the
           # pushed tag is a plain single-arch image, not a manifest list.
           provenance: false
@@ -202,6 +210,9 @@ jobs:
           tags: |
             type=raw,value=${{ inputs.git-sha || github.sha }}
             type=raw,value=latest
+      - name: Set up QEMU for cross-platform build
+        if: ${{ inputs.platforms != 'linux/arm64' }}
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
       # registry cache export needs the docker-container buildx driver (the default
       # docker driver does not support cache-to).
       - name: Set up Docker Buildx
@@ -215,9 +226,9 @@ jobs:
           context: .
           file: ./${{ inputs.docker-file-name }}
           push: true
-          platforms: linux/arm64
-          # provenance/sbom off (with BUILDX_NO_DEFAULT_ATTESTATIONS=1 above) so the
-          # pushed tag is a plain single-arch image, not a manifest list.
+          platforms: ${{ inputs.platforms }}
+          # provenance/sbom off (with BUILDX_NO_DEFAULT_ATTESTATIONS=1 above) to avoid
+          # attestation entries; single-platform pushes a plain image, multi a manifest list.
           provenance: false
           sbom: false
           # Registry-backed BuildKit cache (mode=max) in the same ECR repo, covered by

--- a/.github/workflows/deploy-generic.yml
+++ b/.github/workflows/deploy-generic.yml
@@ -21,6 +21,11 @@ on:
         type: string
         description: "[DEPRECATED] Ignored - all builds and CI run on arm64. No-op kept for backwards compatibility; will be removed in a future release."
         default: "arm64"
+      platforms:
+        required: false
+        type: string
+        default: "linux/arm64"
+        description: 'Target build platforms. Defaults to arm64-only. Set to a comma-separated list (e.g. "linux/amd64,linux/arm64") to push a multi-arch manifest; cross-arch builds run under QEMU.'
       stage:
         required: true
         type: string
@@ -149,6 +154,7 @@ jobs:
       additional-build-args: ${{ inputs.additional-build-args }}
       ecr-repository-name: ${{ inputs.ecr-repository-name }}
       git-sha: ${{ inputs.git-sha }}
+      platforms: ${{ inputs.platforms }}
     secrets:
       AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID }}
       SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}


### PR DESCRIPTION
## What
Adds an opt-in `platforms` input to `component-build.yml` (and forwards it through `deploy-generic.yml`), defaulting to **`linux/arm64`** — i.e. **zero behaviour change for every existing caller**.

A service that sets `platforms: "linux/amd64,linux/arm64"` gets a **multi-arch manifest** pushed instead of a single-arch arm64 image. A `setup-qemu-action` step (pinned, gated on `platforms != 'linux/arm64'`) handles the cross-arch build on the existing arm64 runner — no new runner pools. Wired in both the blacksmith and self-hosted build paths.

## Why
After the ARM64-only switch (#313), `component-build` hardcodes `platforms: linux/arm64` and the `architecture` input is a no-op, so a service **cannot** produce an amd64 image. smart-charge runs a single-threaded MILP solver that is ~2× slower on Graviton than the x86 `m7i` pool it used to run on; we want the ability to fall back to x86. With a multi-arch image, the arm↔x86 node-pool choice becomes a pure, instantly-reversible `kube-manifests` toggle — and the "exec format error" class of incident can't recur.

## Impact / safety
- **Default unchanged**: existing callers don't pass `platforms`, so they still do a single native arm64 build. The QEMU step is skipped for them.
- Opt-in cross-arch builds are slower (QEMU emulation) but smart-charge's image is pure-Python (manylinux wheels, no native compilation), so the emulated `RUN` steps are light.

## Follow-up
Consumer change in data-smart-charge `deploy.yaml` (set `platforms`) lands **after** this merges, since passing an undefined input to the reusable workflow errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EjBGHdgna5BVQVgwFR2inj