### PR TITLE
ci: default Kotlin gradle-args to --parallel --build-cache [NOJIRA]

### DIFF
--- a/.github/workflows/code-coverage-kotlin.yml
+++ b/.github/workflows/code-coverage-kotlin.yml
@@ -69,7 +69,7 @@ on:
       gradle-args:
         required: false
         type: string
-        default: "--no-daemon --parallel"
+        default: "--parallel --build-cache"
         description: 'Additional Gradle arguments'
     secrets:
       TAILSCALE_AUTHKEY:

--- a/.github/workflows/component-test-kotlin.yml
+++ b/.github/workflows/component-test-kotlin.yml
@@ -31,7 +31,7 @@ on:
       gradle-args:
         required: false
         type: string
-        default: "--no-daemon --parallel"
+        default: "--parallel --build-cache"
         description: 'Additional Gradle arguments'
     secrets:
       GHL_USERNAME:

--- a/.github/workflows/deploy-kotlin-v2.yml
+++ b/.github/workflows/deploy-kotlin-v2.yml
@@ -49,7 +49,7 @@ on:
       gradle-args:
         required: false
         type: string
-        default: "--no-daemon --parallel"
+        default: "--parallel --build-cache"
         description: 'Additional Gradle arguments'
       region:
         required: false

--- a/.github/workflows/deploy-kotlin.yml
+++ b/.github/workflows/deploy-kotlin.yml
@@ -49,7 +49,7 @@ on:
       gradle-args:
         required: false
         type: string
-        default: "--no-daemon --parallel"
+        default: "--parallel --build-cache"
         description: 'Additional Gradle arguments'
       region:
         required: false

--- a/.github/workflows/pull-request-kotlin.yml
+++ b/.github/workflows/pull-request-kotlin.yml
@@ -56,7 +56,7 @@ on:
       gradle-args:
         required: false
         type: string
-        default: "--no-daemon --parallel"
+        default: "--parallel --build-cache"
         description: 'Additional Gradle arguments'
       skip-pr-title-check:
         required: false

--- a/.github/workflows/sonar-cloud.yml
+++ b/.github/workflows/sonar-cloud.yml
@@ -31,7 +31,7 @@ on:
       gradle-args:
         required: false
         type: string
-        default: "--no-daemon --parallel"
+        default: "--parallel --build-cache"
         description: 'Additional Gradle arguments'
     secrets:
       TAILSCALE_AUTHKEY:


### PR DESCRIPTION
## Why

service-wallet#4478 sped up its Sonar step by overriding `gradle-args` in the caller: `--parallel --build-cache` instead of the shared default `--no-daemon --parallel`. Dropping `--no-daemon` lets the test/sonar/coverage steps share one warm Gradle daemon, and `--build-cache` lets later invocations reuse outputs.

This promotes that optimization to the **shared Kotlin workflows** so every Kotlin service gets it as the default, instead of each repo overriding per-caller.

## What

Change the `gradle-args` input default from `--no-daemon --parallel` to `--parallel --build-cache` in all reusable Kotlin/Gradle workflows:

- `pull-request-kotlin.yml`
- `sonar-cloud.yml`
- `code-coverage-kotlin.yml`
- `component-test-kotlin.yml`
- `deploy-kotlin.yml`
- `deploy-kotlin-v2.yml`

Input-only change — callers that already pass an explicit `gradle-args` are unaffected.

## Risk / tradeoffs

- **Blast radius: all Kotlin services** that rely on the default. The daemon now persists within/between jobs on the runner. On the standard `large`/blacksmith runners this is the intended setup.
- Any service can revert to the old behaviour by passing `gradle-args: "--no-daemon --parallel"` explicitly.

Draft — open for review before un-drafting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)