### PR TITLE
chore: make SonarQube + Tailscale non-blocking in Kotlin CI [CPONETOPS-1078]

### DIFF
--- a/.github/workflows/pull-request-kotlin.yml
+++ b/.github/workflows/pull-request-kotlin.yml
@@ -51,8 +51,8 @@ on:
       sonar-non-blocking:
         required: false
         type: boolean
-        description: "When true, a failure of the 'Upload results to SonarQube' step does not fail the job"
-        default: false
+        description: "When true (default), a failure of the Tailscale bring-up or the 'Upload results to SonarQube' step does not fail the job. SonarQube depends on the Monta VPN, so infra outages (expired auth key, Tailscale package CDN down, SonarQube unreachable) would otherwise block every PR. Set to false to make SonarQube a hard gate again."
+        default: true
       gradle-args:
         required: false
         type: string
@@ -196,6 +196,7 @@ jobs:
       # automatically for repos still on SonarCloud (no TAILSCALE_AUTHKEY passed).
       - name: Tailscale
         if: ${{ !inputs.skip-sonar && env.TAILSCALE_AUTHKEY != '' }}
+        continue-on-error: ${{ inputs.sonar-non-blocking }}
         uses: tailscale/github-action@6cae46e2d796f265265cfcf628b72a32b4d7cade # v3.3.0
         with:
           authkey: ${{ env.TAILSCALE_AUTHKEY }}

--- a/.github/workflows/sonar-cloud.yml
+++ b/.github/workflows/sonar-cloud.yml
@@ -33,6 +33,11 @@ on:
         type: string
         default: "--no-daemon --parallel"
         description: 'Additional Gradle arguments'
+      sonar-non-blocking:
+        required: false
+        type: boolean
+        description: "When true (default), a failure of the Tailscale bring-up or the SonarQube analysis step does not fail the job; tests still gate. SonarQube depends on the Monta VPN, so infra outages (expired auth key, Tailscale package CDN down, SonarQube unreachable) would otherwise fail the workflow. Set to false to make SonarQube a hard gate again."
+        default: true
     secrets:
       TAILSCALE_AUTHKEY:
         required: false
@@ -97,12 +102,23 @@ jobs:
       # automatically for repos still on SonarCloud (no TAILSCALE_AUTHKEY passed).
       - name: Tailscale
         if: ${{ env.TAILSCALE_AUTHKEY != '' }}
+        continue-on-error: ${{ inputs.sonar-non-blocking }}
         uses: tailscale/github-action@6cae46e2d796f265265cfcf628b72a32b4d7cade # v3.3.0
         with:
           authkey: ${{ env.TAILSCALE_AUTHKEY }}
           hostname: "github-${{ github.run_id }}"
           args: "--login-server https://headscale.monta.com --accept-routes"
-      - name: Build and analyze
+      - name: Run tests with coverage
+        env:
+          GHL_USERNAME: ${{ secrets.GHL_USERNAME }}
+          GHL_PASSWORD: ${{ secrets.GHL_PASSWORD }}
+        uses: monta-app/github-workflows/.github/actions/gradle-multi-module@main
+        with:
+          gradle-module: ${{ inputs.gradle-module }}
+          gradle-tasks: 'test koverXmlReport'
+          gradle-args: ${{ inputs.gradle-args }}
+      - name: Analyze with SonarQube
+        continue-on-error: ${{ inputs.sonar-non-blocking }}
         env:
           GHL_USERNAME: ${{ secrets.GHL_USERNAME }}
           GHL_PASSWORD: ${{ secrets.GHL_PASSWORD }}
@@ -110,7 +126,7 @@ jobs:
         uses: monta-app/github-workflows/.github/actions/gradle-multi-module@main
         with:
           gradle-module: ${{ inputs.gradle-module }}
-          gradle-tasks: 'test koverXmlReport sonar'
+          gradle-tasks: 'sonar'
           gradle-args: ${{ inputs.gradle-args }}
       - name: Upload build reports
         if: always()

--- a/docs/workflow-guide.md
+++ b/docs/workflow-guide.md
@@ -848,13 +848,15 @@ jobs:
 | `kover-report-path` | No | "build/reports/kover/report.xml" | Kover report path |
 | `test-timeout-minutes` | No | 30 | Test timeout |
 | `skip-sonar` | No | false | Skip SonarCloud analysis |
+| `sonar-non-blocking` | No | true | When true, a failure of the Tailscale bring-up or the SonarQube upload does not fail the job (tests still gate). Set to false to make SonarQube a hard gate. |
 
 ### Secrets:
 | Secret | Required | Description |
 |--------|----------|-------------|
+| `TAILSCALE_AUTHKEY` | No | Tailscale auth key. When set, the runner joins the tailnet to reach the self-hosted SonarQube; leave unset to scan SonarCloud. |
 | `GHL_USERNAME` | Yes | GitHub username |
 | `GHL_PASSWORD` | Yes | GitHub token |
-| `SONAR_TOKEN` | Yes | SonarCloud token |
+| `SONAR_TOKEN` | Yes | SonarQube token |
 
 ### Example Usage:
 ```yaml
@@ -1022,9 +1024,10 @@ jobs:
 ### What it does:
 1. Checks out code with full history
 2. Sets up Java environment
-3. Caches SonarCloud packages
-4. Runs Kover coverage report
-5. Uploads analysis to SonarCloud
+3. Caches SonarQube packages
+4. Joins the Tailscale VPN (when `TAILSCALE_AUTHKEY` is set) to reach the self-hosted SonarQube
+5. Runs tests with Kover coverage (gating)
+6. Uploads analysis to SonarQube (best-effort by default)
 
 ### Inputs:
 | Input | Required | Default | Description |
@@ -1033,13 +1036,15 @@ jobs:
 | `use-blacksmith-runners` | No | true | Run on Blacksmith arm64 cloud runners (default). Set to false to run on self-hosted linux-arm64 |
 | `java-version` | No | "21" | Java version |
 | `gradle-module` | No | - | Gradle module name |
+| `sonar-non-blocking` | No | true | When true, a failure of the Tailscale bring-up or the SonarQube analysis step does not fail the job (tests still gate). Set to false to make SonarQube a hard gate. |
 
 ### Secrets:
 | Secret | Required | Description |
 |--------|----------|-------------|
+| `TAILSCALE_AUTHKEY` | No | Tailscale auth key. When set, the runner joins the tailnet to reach the self-hosted SonarQube; leave unset to scan SonarCloud. |
 | `GHL_USERNAME` | Yes | GitHub username |
 | `GHL_PASSWORD` | Yes | GitHub token |
-| `SONAR_TOKEN` | Yes | SonarCloud token |
+| `SONAR_TOKEN` | Yes | SonarQube token |
 
 ### Example Usage:
 ```yaml


### PR DESCRIPTION
## What

Make the Tailscale VPN bring-up and the SonarQube scan **non-blocking by default** in the Kotlin CI workflows, so infra outages on that path stop failing PRs and deploys.

SonarQube is self-hosted behind the Monta VPN, so `pull-request-kotlin.yml` and `sonar-cloud.yml` join Tailscale before scanning. Over the last day this path has repeatedly hard-failed the whole job and blocked deploys:

- headscale `TAILSCALE_AUTHKEY` expired/rotated early
- the Tailscale package CDN returned `504` (the AWS CloudFront incident), so the action couldn't even download the `tailscale` binary
- SonarQube Cloud itself had a disruption

In all these cases SonarQube is advisory, yet the failure gated every Kotlin PR and deploy.

## Changes

- **`pull-request-kotlin.yml`**
  - `continue-on-error` on the `Tailscale` step (previously it had none → any VPN/binary-download failure failed the job)
  - `sonar-non-blocking` now defaults to `true` (the `Upload results to SonarQube` step already honoured it)
  - Lint + tests still gate; only the VPN bring-up and Sonar upload are best-effort
- **`sonar-cloud.yml`**
  - new `sonar-non-blocking` input (default `true`)
  - `continue-on-error` on the `Tailscale` step
  - split the bundled `test koverXmlReport sonar` into a gating **Run tests with coverage** step and a best-effort **Analyze with SonarQube** step, so tests still fail the job but the scan does not (mirrors the structure already used in `pull-request-kotlin.yml`)
- **`docs/workflow-guide.md`** — document `sonar-non-blocking`, the new default, and the optional `TAILSCALE_AUTHKEY` secret

## Behavioural change / tradeoff

SonarQube becomes **advisory by default** for all repos consuming these `@main` workflows. This is the intended fix to unblock deploys during the current outage. The known downside (raised in `#guild-kotlin-backend`): a genuine Sonar quality-gate failure won't block and may go unnoticed. Repos that want SonarQube to remain a hard gate can opt back in with:

```yaml
with:
  sonar-non-blocking: false
```

Longer term the plan discussed is to move Sonar off the VPN path (self-hosted runners fetching directly), which would remove the Tailscale dependency entirely.

## Validation

- `actionlint` passes clean on both changed workflows

CPONETOPS-1078