### PR TITLE
chore: skip SonarQube scan when Tailscale bring-up fails [CPONETOPS-1078]

### DIFF
--- a/.github/workflows/pull-request-kotlin.yml
+++ b/.github/workflows/pull-request-kotlin.yml
@@ -195,6 +195,7 @@ jobs:
       # needs to join the tailnet before the scan step can reach it. Skipped
       # automatically for repos still on SonarCloud (no TAILSCALE_AUTHKEY passed).
       - name: Tailscale
+        id: tailscale
         if: ${{ !inputs.skip-sonar && env.TAILSCALE_AUTHKEY != '' }}
         continue-on-error: ${{ inputs.sonar-non-blocking }}
         uses: tailscale/github-action@6cae46e2d796f265265cfcf628b72a32b4d7cade # v3.3.0
@@ -202,8 +203,11 @@ jobs:
           authkey: ${{ env.TAILSCALE_AUTHKEY }}
           hostname: "github-${{ github.run_id }}"
           args: "--login-server https://headscale.monta.com --accept-routes"
+      # != 'failure' (not == 'success') so the SonarCloud path still runs when
+      # Tailscale is skipped (no TAILSCALE_AUTHKEY); only a failed VPN bring-up,
+      # which leaves SonarQube unreachable, skips the scan.
       - name: Upload results to SonarQube
-        if: ${{ !inputs.skip-sonar }}
+        if: ${{ !inputs.skip-sonar && steps.tailscale.outcome != 'failure' }}
         continue-on-error: ${{ inputs.sonar-non-blocking }}
         env:
           GHL_USERNAME: ${{ secrets.GHL_USERNAME }}

--- a/.github/workflows/pull-request-kotlin.yml
+++ b/.github/workflows/pull-request-kotlin.yml
@@ -203,9 +203,7 @@ jobs:
           authkey: ${{ env.TAILSCALE_AUTHKEY }}
           hostname: "github-${{ github.run_id }}"
           args: "--login-server https://headscale.monta.com --accept-routes"
-      # != 'failure' (not == 'success') so the SonarCloud path still runs when
-      # Tailscale is skipped (no TAILSCALE_AUTHKEY); only a failed VPN bring-up,
-      # which leaves SonarQube unreachable, skips the scan.
+      # != 'failure' (not == 'success') keeps the SonarCloud path when Tailscale is skipped.
       - name: Upload results to SonarQube
         if: ${{ !inputs.skip-sonar && steps.tailscale.outcome != 'failure' }}
         continue-on-error: ${{ inputs.sonar-non-blocking }}

--- a/.github/workflows/sonar-cloud.yml
+++ b/.github/workflows/sonar-cloud.yml
@@ -118,9 +118,7 @@ jobs:
           gradle-module: ${{ inputs.gradle-module }}
           gradle-tasks: 'test koverXmlReport'
           gradle-args: ${{ inputs.gradle-args }}
-      # != 'failure' (not == 'success') so the SonarCloud path still runs when
-      # Tailscale is skipped (no TAILSCALE_AUTHKEY); only a failed VPN bring-up,
-      # which leaves SonarQube unreachable, skips the scan.
+      # != 'failure' (not == 'success') keeps the SonarCloud path when Tailscale is skipped.
       - name: Analyze with SonarQube
         if: ${{ steps.tailscale.outcome != 'failure' }}
         continue-on-error: ${{ inputs.sonar-non-blocking }}

--- a/.github/workflows/sonar-cloud.yml
+++ b/.github/workflows/sonar-cloud.yml
@@ -101,6 +101,7 @@ jobs:
       # needs to join the tailnet before the scan step can reach it. Skipped
       # automatically for repos still on SonarCloud (no TAILSCALE_AUTHKEY passed).
       - name: Tailscale
+        id: tailscale
         if: ${{ env.TAILSCALE_AUTHKEY != '' }}
         continue-on-error: ${{ inputs.sonar-non-blocking }}
         uses: tailscale/github-action@6cae46e2d796f265265cfcf628b72a32b4d7cade # v3.3.0
@@ -117,7 +118,11 @@ jobs:
           gradle-module: ${{ inputs.gradle-module }}
           gradle-tasks: 'test koverXmlReport'
           gradle-args: ${{ inputs.gradle-args }}
+      # != 'failure' (not == 'success') so the SonarCloud path still runs when
+      # Tailscale is skipped (no TAILSCALE_AUTHKEY); only a failed VPN bring-up,
+      # which leaves SonarQube unreachable, skips the scan.
       - name: Analyze with SonarQube
+        if: ${{ steps.tailscale.outcome != 'failure' }}
         continue-on-error: ${{ inputs.sonar-non-blocking }}
         env:
           GHL_USERNAME: ${{ secrets.GHL_USERNAME }}


### PR DESCRIPTION
## What

Follow-up to #320. Gate the SonarQube step on the Tailscale step's outcome so a failed VPN bring-up **skips** the scan instead of running it against a dead VPN.

## Why

#320 made the Tailscale step `continue-on-error`, which stops it from failing the job. But the Sonar step then still ran, failed ~30s later against the unreachable VPN, and logged a confusing error. The job passed, but noisily. Cleaner to skip the scan when the VPN never came up.

Example that motivated this — the `Tailscale` step failed (Tailscale package CDN 504) and the whole job went red: https://github.com/monta-app/service-alerts/actions/runs/29481319142/job/87588587751?pr=60

## Change

- Give the `Tailscale` step `id: tailscale`.
- Gate the Sonar step with `if: steps.tailscale.outcome != 'failure'`.

`!= 'failure'` (rather than `== 'success'`) is deliberate: when no `TAILSCALE_AUTHKEY` is passed the Tailscale step is *skipped* (outcome `skipped`), and those repos are still on SonarCloud — they must keep scanning. Only a genuine failed bring-up (`failure`) skips the scan.

Applied to both `pull-request-kotlin.yml` and `sonar-cloud.yml`.

### Behaviour matrix (test job)

| authkey | VPN | sonar-non-blocking | Tailscale | Sonar | Job |
|---|---|---|---|---|---|
| unset | – | true (default) | skipped | runs (SonarCloud) | pass |
| set | up | true | success | runs | pass |
| set | down | true | failed→continued | **skipped** | **pass** |
| set | down | false | failed→job fails | skipped | fail (hard gate) |

## Note on re-runs

Re-running an *old* run (e.g. attempt 5 of a run created before #320 merged) executes the pre-fix workflow — that's why the example above still went red. A fresh run / new commit picks up `@main`.

## Validation

- `actionlint` passes clean on both workflows

CPONETOPS-1078