### PR TITLE
fix: drop --accept-routes from tailscale args (v4 passes it by default)

### DIFF
--- a/.github/workflows/pull-request-kotlin.yml
+++ b/.github/workflows/pull-request-kotlin.yml
@@ -202,7 +202,8 @@ jobs:
         with:
           authkey: ${{ env.TAILSCALE_AUTHKEY }}
           hostname: "github-${{ github.run_id }}"
-          args: "--login-server https://headscale.monta.com --accept-routes"
+          # v4 passes --accept-routes itself; repeating it in args fails `tailscale up`
+          args: "--login-server https://headscale.monta.com"
       # Wait for the tailnet path to SonarQube to actually be usable before
       # scanning. `tailscale up` returns before DERP/route programming has
       # settled, so the scanner's first call (GET /api/v2/analysis/version)

--- a/.github/workflows/sonar-cloud.yml
+++ b/.github/workflows/sonar-cloud.yml
@@ -108,7 +108,8 @@ jobs:
         with:
           authkey: ${{ env.TAILSCALE_AUTHKEY }}
           hostname: "github-${{ github.run_id }}"
-          args: "--login-server https://headscale.monta.com --accept-routes"
+          # v4 passes --accept-routes itself; repeating it in args fails `tailscale up`
+          args: "--login-server https://headscale.monta.com"
       - name: Run tests with coverage
         env:
           GHL_USERNAME: ${{ secrets.GHL_USERNAME }}


### PR DESCRIPTION
## Problem

Validation of #311 (tailscale/github-action v3.3.0 → v4.1.3) via a fresh consumer run ([service-audit-log run 30360531261](https://github.com/monta-app/service-audit-log/actions/runs/30360531261)) showed every `tailscale up` attempt failing:

```
invalid boolean flag accept-routes: flag provided multiple times
```

v4 hardcodes `--accept-routes` in the `up` command ([src/main.ts L771](https://github.com/tailscale/github-action/blob/780049a30b6ff5c378a9e7b389d15ece7a204888/src/main.ts#L771)) — an undocumented breaking change — so our `args: "... --accept-routes"` duplicates the flag. `continue-on-error: sonar-non-blocking` masks the failure, so affected runs go green while **silently skipping the SonarQube scan** (or fail hard where sonar-non-blocking is off).

## Fix

Remove `--accept-routes` from `args` in both workflows; v4 applies it unconditionally, so effective behavior is unchanged. `--login-server` (Headscale) is still passed through `args` as before.

## Validation

After merge, re-validate the same way: retrigger a consumer PR (e.g. close/reopen a Renovate PR in service-audit-log) and confirm the Tailscale step joins on attempt 1 and the "Upload results to SonarQube" step runs instead of skipping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)