### PR TITLE
feat: forward release-notification inputs to changelog-cli-action [CPONETOPS-1176]

### DIFF
--- a/.github/workflows/deploy-kotlin-v2.yml
+++ b/.github/workflows/deploy-kotlin-v2.yml
@@ -101,6 +101,14 @@ on:
         type: boolean
         default: true
         description: 'Comment on JIRA tickets with production deployment information (automatically disabled if requirements not met)'
+      changelog-monitoring-urls:
+        required: false
+        type: string
+        description: "Comma-separated list of dashboard/monitoring URLs for the release notification - example: Grafana|https://grafana.monta.app/d/my-service,Sentry|https://sentry.io/my-service"
+      changelog-release-notify-channel:
+        required: false
+        type: string
+        description: 'Slack channel ID or name to post a release notification to, tagging PR authors/co-authors/approvers and linking changelog-monitoring-urls. Independent of enable-changelog - setting this is what enables the notification.'
       run-tests:
         required: false
         type: boolean
@@ -338,3 +346,5 @@ jobs:
           deployment-url: ${{ needs.deploy.outputs.deployment-url }}
           comment-on-prs: ${{ inputs.comment-on-prs }}
           comment-on-jira: ${{ inputs.comment-on-jira }}
+          monitoring-urls: ${{ inputs.changelog-monitoring-urls }}
+          release-notify-channel: ${{ inputs.changelog-release-notify-channel }}

--- a/.github/workflows/deploy-kotlin.yml
+++ b/.github/workflows/deploy-kotlin.yml
@@ -101,6 +101,14 @@ on:
         type: boolean
         default: true
         description: 'Comment on JIRA tickets with production deployment information (automatically disabled if requirements not met)'
+      changelog-monitoring-urls:
+        required: false
+        type: string
+        description: "Comma-separated list of dashboard/monitoring URLs for the release notification - example: Grafana|https://grafana.monta.app/d/my-service,Sentry|https://sentry.io/my-service"
+      changelog-release-notify-channel:
+        required: false
+        type: string
+        description: 'Slack channel ID or name to post a release notification to, tagging PR authors/co-authors/approvers and linking changelog-monitoring-urls. Independent of enable-changelog - setting this is what enables the notification.'
       run-tests:
         required: false
         type: boolean
@@ -323,3 +331,5 @@ jobs:
           deployment-url: ${{ needs.deploy.outputs.deployment-url }}
           comment-on-prs: ${{ inputs.comment-on-prs }}
           comment-on-jira: ${{ inputs.comment-on-jira }}
+          monitoring-urls: ${{ inputs.changelog-monitoring-urls }}
+          release-notify-channel: ${{ inputs.changelog-release-notify-channel }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,11 +1,14 @@
 # Claude Code Notes
 
 ## Last Documentation Update
-- **Date**: 2026-06-17
+- **Date**: 2026-08-06
 - **Latest SHA**: bf4f995 (check for newer commits)
-- **Changes**: Removed all x86/amd64 image building; builds are now ARM64-only
+- **Changes**: Changelog Release Notifications
 
-## Recent Workflow Changes (2026-06-17)
+## Recent Workflow Changes (2026-08-06)
+1. **Changelog Release Notifications**: Added `changelog-monitoring-urls` and `changelog-release-notify-channel` inputs to `deploy-kotlin.yml` and `deploy-kotlin-v2.yml`, forwarded to the `changelog-cli-action`'s `monitoring-urls`/`release-notify-channel` inputs. Posts a standalone Slack message with the release link, dashboards to monitor, and tagged PR authors/co-authors/approvers - independent of `enable-changelog`/`output`, reuses the existing `SLACK_APP_TOKEN` secret.
+
+## Previous Changes (2026-06-17)
 1. **ARM64-only image builds**: Purged all x86/amd64 support from the build and CI surface
    - `component-build.yml`: removed the amd64+arm64 build matrix and the `create-manifest` job. Now does a single native ARM64 build (`platforms: linux/arm64`) that pushes the `<sha>` and `latest` tags directly, with no per-arch suffixes and no multi-arch manifest list. The setup job resolves a single arm64 runner and the buildcache is no longer per-arch scoped.
    - `runner-size-converter` action: dropped the `architecture` input; always emits `linux-arm64` / `linux-arm64-xl`.

--- a/docs/workflow-guide.md
+++ b/docs/workflow-guide.md
@@ -431,6 +431,8 @@ This conditional logic ensures the workflow continues properly even when optiona
 | `enable-changelog` | No | false | Enable changelog generation after deployment |
 | `changelog-tag-pattern` | No | - | Regex pattern for matching tag patterns (group 1 should match version) - example: processor-(.*) |
 | `changelog-path-exclude-pattern` | No | - | Regex pattern for excluding file paths from changelog - example: ^gateway/ |
+| `changelog-monitoring-urls` | No | - | Comma-separated list of dashboard/monitoring URLs for the release notification - example: Grafana\|https://grafana.monta.app/d/my-service,Sentry\|https://sentry.io/my-service |
+| `changelog-release-notify-channel` | No | - | Slack channel ID or name to post a release notification to, tagging PR authors/co-authors/approvers. Independent of `enable-changelog` - setting this is what enables the notification |
 
 ### Secrets:
 | Secret | Required | Description |
@@ -495,6 +497,9 @@ jobs:
       changelog-tag-pattern: "charging-(.*)"
       # Optional: Exclude paths from changelog (e.g., other services)
       changelog-path-exclude-pattern: "^(payment|vehicle)/"
+      # Optional: Release notification with dashboard links, tagging contributors
+      changelog-release-notify-channel: "#charging-releases"
+      changelog-monitoring-urls: "Grafana|https://grafana.monta.app/d/charging,Sentry|https://sentry.io/charging"
     secrets:
       GHL_USERNAME: ${{ secrets.GHL_USERNAME }}
       GHL_PASSWORD: ${{ secrets.GHL_PASSWORD }}
@@ -622,6 +627,8 @@ jobs:
 | `enable-changelog` | No | false | Enable changelog generation |
 | `changelog-tag-pattern` | No | - | Regex pattern for tag matching (monorepo filtering) |
 | `changelog-path-exclude-pattern` | No | - | Regex pattern for excluding paths from changelog |
+| `changelog-monitoring-urls` | No | - | Comma-separated list of dashboard/monitoring URLs for the release notification |
+| `changelog-release-notify-channel` | No | - | Slack channel to post a release notification to, tagging PR authors/co-authors/approvers. Independent of `enable-changelog` |
 | `comment-on-prs` | No | true | Comment on PRs with deployment info |
 | `comment-on-jira` | No | true | Comment on JIRA tickets with deployment info |
 
@@ -730,6 +737,9 @@ jobs:
       release-tag-prefix: "gateway"
       enable-changelog: true
       changelog-tag-pattern: "gateway-(.*)"
+      # Optional: Release notification with dashboard links, tagging contributors
+      changelog-release-notify-channel: "#gateway-releases"
+      changelog-monitoring-urls: "Grafana|https://grafana.monta.app/d/gateway"
       argocd-server: "argocd.monta.app"
       comment-on-prs: true
       comment-on-jira: true


### PR DESCRIPTION
Adds `changelog-monitoring-urls` and `changelog-release-notify-channel` inputs to `deploy-kotlin.yml` and `deploy-kotlin-v2.yml`, forwarded to the `changelog-cli-action`'s `monitoring-urls`/`release-notify-channel` inputs. This lets callers opt into a standalone Slack release notification - the release link, dashboards to monitor, and tagged PR authors/co-authors/approvers - independent of `enable-changelog`, and reuses the existing `SLACK_APP_TOKEN` secret.

Note: this is inert until changelog-cli-action pins a changelog-cli release that has this feature - neither is released yet.

Need https://github.com/monta-app/changelog-cli-action/pull/81 to go in first